### PR TITLE
ui: fix #117

### DIFF
--- a/packages/ui-default/components/tab/tab.page.styl
+++ b/packages/ui-default/components/tab/tab.page.styl
@@ -78,7 +78,6 @@
 
 .section__tab-content
   position: relative
-  white-space: nowrap
 
   .section__tab-main
     display: none


### PR DESCRIPTION
分析 #117 后发现，父元素 `div.section__tab-content` 具有 `white-space: nowrap` 属性，根据 [Stack Overflow 上的搜索结果](https://stackoverflow.com/questions/10743763/word-wrap-break-word-does-not-work-in-this-example)：

> Make sure you specify `width` and notice if there are any overriding attributes in parent nodes.
> Make sure there is not `white-space: nowrap`.

该元素的位置：

![position_of_the_div](https://user-images.githubusercontent.com/45730483/116023681-3084d080-a67f-11eb-8e2a-cc3b6cb2664f.png)

可以认为此处 `white-space: nowrap` 属性并不必要，如有需要，应为其子元素添加该属性。
