### PR TITLE
ui: fix #102

### DIFF
--- a/packages/ui-default/components/tab/tab.page.styl
+++ b/packages/ui-default/components/tab/tab.page.styl
@@ -78,7 +78,6 @@
 
 .section__tab-content
   position: relative
-  white-space: nowrap
 
   .section__tab-main
     display: none

--- a/packages/ui-default/misc/structure.styl
+++ b/packages/ui-default/misc/structure.styl
@@ -26,6 +26,9 @@
   +mobile()
     padding: 0
 
+.monaco-editor .main
+  padding: 0
+
 .v-center
   vertical-align: middle
 


### PR DESCRIPTION
#102 是全局样式 `.main` 意外作用于 Monaco 生成的自动补全提示结构 `.monaco-editor .suggest-widget .monaco-list .monaco-list-row>.contents>.main`，为其增加了错误的 `padding` 所致，补充额外规则：

```stylus
.monaco-editor .main
  padding: 0
```

即可解决。

:warning: 全局样式的存在仍具有潜在风险，可能还会造成类似的破坏，建议在未来的设计中改进。
