### PR TITLE
ui: fix ol style for vditor preview

### DIFF
--- a/packages/ui-default/components/cmeditor/cmeditor.styl
+++ b/packages/ui-default/components/cmeditor/cmeditor.styl
@@ -3,3 +3,6 @@
 
 .vditor-preview__action
   display: none
+
+.vditor ol
+  list-style: decimal

--- a/packages/ui-default/misc/typography.styl
+++ b/packages/ui-default/misc/typography.styl
@@ -138,9 +138,6 @@ address, caption, cite, th, var
 ul, ol
   list-style: none
 
-.vditor ol
-  list-style: decimal
-
 caption, th
   text-align: left
 

--- a/packages/ui-default/misc/typography.styl
+++ b/packages/ui-default/misc/typography.styl
@@ -138,6 +138,9 @@ address, caption, cite, th, var
 ul, ol
   list-style: none
 
+.vditor ol
+  list-style: decimal
+
 caption, th
   text-align: left
 


### PR DESCRIPTION
修复了 vditor 预览时 `ol` 列表没有序号的问题。

这个问题还是因为该死的全局样式。

提交之后能看到序号是因为在 `.typo` 下它是有序号的，裸的就没有。而且此时不能直接为 vditor 的预览区添加 `.typo` 样式，冲突很大，非常麻烦，没有任何意义。

在上一个 PR 中已经说过，全局样式的存在非常麻烦，可能会引发很多莫名其妙而且该死的 UI 问题。
