### PR TITLE
core: optimize template loading speed

### DIFF
--- a/packages/ui-default/backendlib/template.js
+++ b/packages/ui-default/backendlib/template.js
@@ -35,15 +35,21 @@ class Loader extends nunjucks.Loader {
         return {
           src: global.Hydro.ui.template[name],
           path: name,
-          noCache: true,
+          noCache: false,
         };
       }
       throw new Error(`Cannot get template ${name}`);
     }
+    if (process.env.DEV) {
+      fs.watchFile(p, () => {
+        global.Hydro.ui.template[name] = fs.readFileSync(p, 'utf-8').toString();
+        this.emit('update', name);
+      });
+    }
     return {
       src: fs.readFileSync(fullpath, 'utf-8').toString(),
       path: fullpath,
-      noCache: true,
+      noCache: false,
     };
   }
 }


### PR DESCRIPTION
开启nunjucks cache，开发模式下通过file watcher监听文件变化更新cache，可以减少同步io请求，大幅提升模板渲染速度