### PR TITLE
fix: java compiler unable to create thread

### DIFF
--- a/packages/hydrojudge/src/sandbox.ts
+++ b/packages/hydrojudge/src/sandbox.ts
@@ -27,7 +27,7 @@ function proc({
     execute = '',
     time = 16000,
     memory = parseMemoryMB(getConfig('memoryMax')),
-    process_limit = 32,
+    process_limit = 64,
     stdin = '', copyIn = {}, copyOut = [], copyOutCached = [],
 } = {}) {
     if (!supportOptional) {


### PR DESCRIPTION
适当调大沙箱proc限制，防止java编译器无法创建线程导致CE的情况