### PR TITLE
限制 golang 编译使用线程数

### DIFF
--- a/packages/hydrooj/setting.yaml
+++ b/packages/hydrooj/setting.yaml
@@ -94,7 +94,7 @@ langs:
       highlight: javascript
       display: Javascript (JSC)
     go:
-      compile: /usr/bin/go build -o ${name} foo.go
+      compile: /usr/bin/go build -p 1 -o ${name} foo.go
       display: Golang
     rb:
       execute: /usr/bin/ruby foo.rb


### PR DESCRIPTION
将 golang 编译线程数设为 1 以避开沙箱限制。