### PR TITLE
core: fix compile error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ __*
 !__mocks__
 !.gitkeep
 *.local
+.idea

--- a/build/prepare.js
+++ b/build/prepare.js
@@ -13,6 +13,7 @@ const compilerOptionsBase = {
     experimentalDecorators: true,
     emitDecoratorMetadata: true,
     noEmit: true,
+    skipLibCheck: true,
 };
 const config = {
     compilerOptions: compilerOptionsBase,

--- a/packages/hydrooj/src/model/domain.ts
+++ b/packages/hydrooj/src/model/domain.ts
@@ -92,7 +92,7 @@ class DomainModel {
         const res = await coll.findOneAndUpdate(
             { _id: domainId },
             // FIXME
-            // @ts-expect-error
+            // @ts-ignore
             { $inc: { [field]: n } },
             { returnDocument: 'after' },
         );


### PR DESCRIPTION
`graphql-scalars` now is incomplicated with `graph-js`. To make build successful, `skipLibCheck` flag have been added.