### PR TITLE
ui:fix style

### DIFF
--- a/packages/ui-default/components/form/textbox.page.styl
+++ b/packages/ui-default/components/form/textbox.page.styl
@@ -25,6 +25,7 @@ textarea.textbox
 
 div.textbox
   min-height: rem(200px)
+  margin-bottom: 1rem
 
 .data-table
   input.textbox, textarea.textbox

--- a/packages/ui-default/templates/record_main.html
+++ b/packages/ui-default/templates/record_main.html
@@ -44,7 +44,7 @@
               <label>
                 {{ _('By Status') }}
               </label>
-              <select class="inline compact select" name="status">
+              <select class="compact select" name="status">
                   <option value="">{{ _('All Submissions') }}</option>
                   <option value="1">Accepted</option>
                   <option value="2">Wrong Answer</option>


### PR DESCRIPTION
1. add div.textbox margin-bottom to fix help-text
2. remove inline class to fix record filter select display auto width will overflow
![image](https://user-images.githubusercontent.com/15662967/148633540-cd314793-24fd-41e8-b9b0-c1bd79d6c073.png)
![image](https://user-images.githubusercontent.com/15662967/148633549-6473e69e-2922-4492-aba8-d77dd219ae6d.png)
