### PR TITLE
ui: special behavior of `UserSelectAutoComplete` when `multi`

### DIFF
--- a/packages/ui-default/components/autocomplete/UserSelectAutoComplete.jsx
+++ b/packages/ui-default/components/autocomplete/UserSelectAutoComplete.jsx
@@ -15,6 +15,11 @@ export default class UserSelectAutoComplete extends AutoComplete {
     });
   }
 
+  value() {
+    if (this.options.multi) return this.ref?.getSelectedItems().map((item) => item._id) ?? this.$dom.val();
+    return this.ref?.getSelectedItems()[0] ?? null;
+  }
+
   attach() {
     const value = this.$dom.val();
     ReactDOM.render(

--- a/packages/ui-default/components/autocomplete/UserSelectAutoComplete.jsx
+++ b/packages/ui-default/components/autocomplete/UserSelectAutoComplete.jsx
@@ -14,7 +14,17 @@ export default class UserSelectAutoComplete extends AutoComplete {
       classes: 'user-select',
       ...options,
     });
-    this.client = new QueryClient();
+    this.client = new QueryClient({
+      defaultOptions: {
+        queries: {
+          refetchOnWindowFocus: false,
+          refetchOnMount: false,
+          refetchOnReconnect: false,
+          retry: false,
+          staleTime: Infinity,
+        },
+      },
+    });
   }
 
   value() {

--- a/packages/ui-default/components/autocomplete/UserSelectAutoComplete.jsx
+++ b/packages/ui-default/components/autocomplete/UserSelectAutoComplete.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { assign } from 'lodash';
 import DOMAttachedObject from 'vj/components/DOMAttachedObject';
 import AutoComplete from '.';
@@ -13,6 +14,7 @@ export default class UserSelectAutoComplete extends AutoComplete {
       classes: 'user-select',
       ...options,
     });
+    this.client = new QueryClient();
   }
 
   value() {
@@ -23,14 +25,16 @@ export default class UserSelectAutoComplete extends AutoComplete {
   attach() {
     const value = this.$dom.val();
     ReactDOM.render(
-      <UserSelectAutoCompleteFC
-        ref={(ref) => { this.ref = ref; }}
-        height="34px"
-        defaultItems={value}
-        onChange={this.onChange}
-        multi={this.options.multi}
-        freeSolo={this.options.multi}
-      />,
+      <QueryClientProvider client={this.client}>
+        <UserSelectAutoCompleteFC
+          ref={(ref) => { this.ref = ref; }}
+          height="34px"
+          defaultItems={value}
+          onChange={this.onChange}
+          multi={this.options.multi}
+          freeSolo={this.options.multi}
+        />
+      </QueryClientProvider>,
       this.container,
     );
   }

--- a/packages/ui-default/components/autocomplete/components/AutoComplete.jsx
+++ b/packages/ui-default/components/autocomplete/components/AutoComplete.jsx
@@ -204,31 +204,31 @@ const AutoComplete = forwardRef(function AutoComplete(props, ref) {
             <Icon name="close" onClick={() => toggleItem(item)} />
           </div>
         ))}
-        {disabled ? (
+        {disabled && (
           <input
             disabled
             autoComplete="off"
             value={disabledHint}
           />
-        ) : (
-          <input
-            ref={inputRef}
-            autoComplete="off"
-            onChange={(e) => {
-              dispatchChange();
-              handleInputChange(e);
-            }}
-            onFocus={() => {
-              setFocused(true);
-              if (allowEmptyQuery) {
-                handleInputChange();
-              }
-            }}
-            onBlur={() => setFocused(false)}
-            onKeyDown={handleInputKeyDown}
-            defaultValue={multi ? '' : defaultItems.join(',')}
-          />
         )}
+        <input
+          ref={inputRef}
+          autoComplete="off"
+          hidden={disabled}
+          onChange={(e) => {
+            dispatchChange();
+            handleInputChange(e);
+          }}
+          onFocus={() => {
+            setFocused(true);
+            if (allowEmptyQuery) {
+              handleInputChange();
+            }
+          }}
+          onBlur={() => setFocused(false)}
+          onKeyDown={handleInputKeyDown}
+          defaultValue={multi ? '' : defaultItems.join(',')}
+        />
       </div>
       {focused && itemList.length > 0 && (
         <ul ref={listRef} className="autocomplete-list" style={listStyle} onMouseDown={(e) => e.preventDefault()}>

--- a/packages/ui-default/components/autocomplete/components/AutoComplete.jsx
+++ b/packages/ui-default/components/autocomplete/components/AutoComplete.jsx
@@ -13,6 +13,7 @@ const AutoComplete = forwardRef(function AutoComplete(props, ref) {
   // if you need fix height, set to at least "30px"
   // for Hydro, no less then "34px" can be better
   const height = props.height ?? 'auto';
+  const disabled = props.disabled ?? false;
   const listStyle = props.listStyle ?? {};
   const itemsFn = props.itemsFn ?? (async () => []);
   const renderItem = props.renderItem ?? ((item) => item);
@@ -22,7 +23,7 @@ const AutoComplete = forwardRef(function AutoComplete(props, ref) {
   const multi = props.multi ?? false;
   const rawDefaultItems = props.defaultItems ?? [];
   const defaultItems = typeof rawDefaultItems === 'string'
-    ? props.defaultItems.split(',').map((i) => i.trim()).filter((i) => i.length > 0) : rawDefaultItems;
+    ? rawDefaultItems.split(',').map((i) => i.trim()).filter((i) => i.length > 0) : rawDefaultItems;
   const allowEmptyQuery = props.allowEmptyQuery ?? false;
   const freeSolo = props.freeSolo ?? false;
   const freeSoloConverter = freeSolo ? props.freeSoloConverter ?? ((i) => i) : ((i) => i);
@@ -204,6 +205,8 @@ const AutoComplete = forwardRef(function AutoComplete(props, ref) {
         ))}
         <input
           ref={inputRef}
+          disabled={disabled}
+          placeholder={disabled ? 'Loading...' : ''}
           autoComplete="off"
           onChange={(e) => {
             dispatchChange();
@@ -243,6 +246,7 @@ const AutoComplete = forwardRef(function AutoComplete(props, ref) {
 AutoComplete.propTypes = {
   width: PropTypes.string,
   height: PropTypes.string,
+  disabled: PropTypes.bool,
   listStyle: PropTypes.object,
   itemsFn: PropTypes.func.isRequired,
   itemKey: PropTypes.func,
@@ -259,6 +263,7 @@ AutoComplete.propTypes = {
 AutoComplete.defaultProps = {
   width: '100%',
   height: 'auto',
+  disabled: false,
   listStyle: {},
   renderItem: (item) => item,
   itemText: (item) => item,

--- a/packages/ui-default/components/autocomplete/components/AutoComplete.jsx
+++ b/packages/ui-default/components/autocomplete/components/AutoComplete.jsx
@@ -14,6 +14,7 @@ const AutoComplete = forwardRef(function AutoComplete(props, ref) {
   // for Hydro, no less then "34px" can be better
   const height = props.height ?? 'auto';
   const disabled = props.disabled ?? false;
+  const disabledHint = props.disabledHint ?? '';
   const listStyle = props.listStyle ?? {};
   const itemsFn = props.itemsFn ?? (async () => []);
   const renderItem = props.renderItem ?? ((item) => item);
@@ -189,7 +190,7 @@ const AutoComplete = forwardRef(function AutoComplete(props, ref) {
       setFocused(true);
       inputRef.current?.focus();
     },
-  }));
+  }), [selected, selectedKeys, inputRef, multi]);
 
   return (
     <div style={{ display: 'inline-block', width: '100%' }}>
@@ -203,25 +204,31 @@ const AutoComplete = forwardRef(function AutoComplete(props, ref) {
             <Icon name="close" onClick={() => toggleItem(item)} />
           </div>
         ))}
-        <input
-          ref={inputRef}
-          disabled={disabled}
-          placeholder={disabled ? 'Loading...' : ''}
-          autoComplete="off"
-          onChange={(e) => {
-            dispatchChange();
-            handleInputChange(e);
-          }}
-          onFocus={() => {
-            setFocused(true);
-            if (allowEmptyQuery) {
-              handleInputChange();
-            }
-          }}
-          onBlur={() => setFocused(false)}
-          onKeyDown={handleInputKeyDown}
-          defaultValue={multi ? '' : defaultItems.join(',')}
-        />
+        {disabled ? (
+          <input
+            disabled
+            autoComplete="off"
+            value={disabledHint}
+          />
+        ) : (
+          <input
+            ref={inputRef}
+            autoComplete="off"
+            onChange={(e) => {
+              dispatchChange();
+              handleInputChange(e);
+            }}
+            onFocus={() => {
+              setFocused(true);
+              if (allowEmptyQuery) {
+                handleInputChange();
+              }
+            }}
+            onBlur={() => setFocused(false)}
+            onKeyDown={handleInputKeyDown}
+            defaultValue={multi ? '' : defaultItems.join(',')}
+          />
+        )}
       </div>
       {focused && itemList.length > 0 && (
         <ul ref={listRef} className="autocomplete-list" style={listStyle} onMouseDown={(e) => e.preventDefault()}>
@@ -247,6 +254,7 @@ AutoComplete.propTypes = {
   width: PropTypes.string,
   height: PropTypes.string,
   disabled: PropTypes.bool,
+  disabledHint: PropTypes.string,
   listStyle: PropTypes.object,
   itemsFn: PropTypes.func.isRequired,
   itemKey: PropTypes.func,
@@ -264,6 +272,7 @@ AutoComplete.defaultProps = {
   width: '100%',
   height: 'auto',
   disabled: false,
+  disabledHint: '',
   listStyle: {},
   renderItem: (item) => item,
   itemText: (item) => item,

--- a/packages/ui-default/components/autocomplete/components/UserSelectAutoComplete.jsx
+++ b/packages/ui-default/components/autocomplete/components/UserSelectAutoComplete.jsx
@@ -95,7 +95,7 @@ UserSelectAutoComplete.defaultProps = {
   height: 'auto',
   listStyle: {},
   multi: false,
-  defaultItems: [],
+  defaultItems: '',
   allowEmptyQuery: false,
   freeSolo: false,
   freeSoloConverter: (input) => input,

--- a/packages/ui-default/components/autocomplete/components/UserSelectAutoComplete.jsx
+++ b/packages/ui-default/components/autocomplete/components/UserSelectAutoComplete.jsx
@@ -49,6 +49,8 @@ const UserSelectAutoComplete = forwardRef(function UserSelectAutoComplete(props,
 
   const itemText = (user) => user.uname || user;
 
+  const itemKey = (user) => user._id;
+
   const renderItem = (user) => (
     <div className="media">
       <div className="media__left medium">
@@ -69,6 +71,7 @@ const UserSelectAutoComplete = forwardRef(function UserSelectAutoComplete(props,
       disabledHint="Loading..."
       itemsFn={itemsFn}
       itemText={itemText}
+      itemKey={multi ? itemKey : itemText}
       renderItem={renderItem}
       defaultItems={multi ? [] : rawDefaultItems}
     />

--- a/packages/ui-default/components/autocomplete/components/UserSelectAutoComplete.jsx
+++ b/packages/ui-default/components/autocomplete/components/UserSelectAutoComplete.jsx
@@ -13,16 +13,14 @@ const UserSelectAutoComplete = forwardRef(function UserSelectAutoComplete(props,
     .filter((i) => i.length > 0)
     .map((i) => +i);
 
-  const { isLoading } = useQuery(['default_user', defaultItems], async () => {
-    if (defaultItems.length === 0) return;
-    const items = await api(gql`
+  const { isLoading, data } = useQuery(['default_user', defaultItems], () => (
+    (defaultItems.length === 0) ? [] : api(gql`
       users(ids: ${defaultItems}) {
         _id
         uname
       }
-    `, ['data', 'users']);
-    ref.setSelectedItems(items);
-  });
+    `, ['data', 'users'])
+  ));
 
   const itemsFn = (query) => api(gql`
     users(search: ${query}) {
@@ -50,10 +48,11 @@ const UserSelectAutoComplete = forwardRef(function UserSelectAutoComplete(props,
     <AutoComplete
       ref={ref}
       disabled={isLoading}
+      disabledHint="Loading..."
       itemsFn={itemsFn}
       itemText={itemText}
       renderItem={renderItem}
-      defaultItems={[]}
+      defaultItems={data}
       {...props}
     />
   );

--- a/packages/ui-default/components/autocomplete/components/UserSelectAutoComplete.jsx
+++ b/packages/ui-default/components/autocomplete/components/UserSelectAutoComplete.jsx
@@ -16,7 +16,7 @@ const UserSelectAutoComplete = forwardRef(function UserSelectAutoComplete(props,
   const { isLoading } = useQuery(['default_user', defaultItems], async () => {
     if (defaultItems.length === 0) return;
     const items = await api(gql`
-      users(id: ${defaultItems}) {
+      users(ids: ${defaultItems}) {
         _id
         uname
       }

--- a/packages/ui-default/package.json
+++ b/packages/ui-default/package.json
@@ -115,6 +115,7 @@
     "markdown-it-table-of-contents": "^0.6.0",
     "mongodb": "^3.7.3",
     "nunjucks": "^3.2.3",
+    "react-query": "^3.34.7",
     "streamsaver": "^2.0.5",
     "xss": "^1.0.10"
   }


### PR DESCRIPTION
当 `UserSelectAutoComplete` 的 `multi` 被设置为 `true` 时，增加了新的约束：

- 如果有初始值，初始值必须以 uid 形式给出

增加了新的特性：

- 使用 uid 作为 key（实际 value），用户名作为显示文本
- 当有初始值时，根据初始值做 prefetch，确保内部已选项目列表是 `object[]`

当 `multi` 为 `false` 时，上述约束和特性不适用，行为不变。
