### PR TITLE
judge: support binary output

### DIFF
--- a/packages/hydrojudge/src/check.ts
+++ b/packages/hydrojudge/src/check.ts
@@ -11,12 +11,12 @@ const testlibSrc = findFileSync('@hydrooj/hydrojudge/vendor/testlib/testlib.h');
 
 interface CheckConfig {
     checker_type: string;
-    stdin: string,
-    stdout: string,
-    user_stdout: string,
-    user_stderr: string,
-    score: number,
+    stdin: CopyInFile,
+    stdout: CopyInFile,
+    user_stdout: CopyInFile,
+    user_stderr: CopyInFile,
     copyIn?: Record<string, CopyInFile>,
+    score: number,
     detail: boolean,
 }
 

--- a/packages/hydrojudge/src/compile.ts
+++ b/packages/hydrojudge/src/compile.ts
@@ -3,10 +3,11 @@ import { STATUS } from '@hydrooj/utils/lib/status';
 import { CompileError } from './error';
 import { Execute } from './interface';
 import { del, run } from './sandbox';
+import { CopyInFile } from './sandbox/interface';
 import { compilerText } from './utils';
 
 export = async function compile(
-    lang: LangConfig, code: string, target: string, copyIn: any = {}, next?: Function,
+    lang: LangConfig, code: string, target: string, copyIn: Record<string, CopyInFile> = {}, next?: Function,
 ): Promise<Execute> {
     target = lang.target || target;
     copyIn[lang.code_file] = { content: code };

--- a/packages/hydrojudge/src/interface.ts
+++ b/packages/hydrojudge/src/interface.ts
@@ -8,5 +8,5 @@ export interface Execute {
 export interface CompileErrorInfo {
     stdout?: string,
     stderr?: string,
-    status?: string
+    status?: number
 }

--- a/packages/hydrojudge/src/judge/default.ts
+++ b/packages/hydrojudge/src/judge/default.ts
@@ -1,12 +1,10 @@
-import path from 'path';
-import fs from 'fs-extra';
 import Queue from 'p-queue';
 import { STATUS } from '@hydrooj/utils/lib/status';
 import { check, compileChecker } from '../check';
 import compile from '../compile';
 import { getConfig } from '../config';
 import { CompileError, FormatError } from '../error';
-import { run } from '../sandbox';
+import { del, run } from '../sandbox';
 import signals from '../signals';
 import { parseFilename } from '../utils';
 import {
@@ -40,26 +38,25 @@ function judgeCase(c: Case, sid: string) {
         const { filename } = ctx.config;
         const copyIn = { ...ctx.execute.copyIn };
         if (filename) copyIn[`${filename}.in`] = c.input ? { src: c.input } : { content: '' };
-        const copyOut = filename ? [`${filename}.out?`] : [];
+        const copyOutCached = filename ? [`${filename}.out?`] : [];
         const stdin = filename ? null : c.input;
-        const stdout = path.resolve(ctx.tmpdir, `${c.id}.out`);
-        const stderr = path.resolve(ctx.tmpdir, `${c.id}.err`);
         const res = await run(
             ctx.execute.execute.replace(/\$\{name\}/g, 'code'),
             {
                 stdin,
-                stdout: filename ? null : stdout,
-                stderr,
                 copyIn,
-                copyOut,
+                copyOutCached,
                 time: ctxSubtask.subtask.time * ctx.execute.time,
                 memory: ctxSubtask.subtask.memory,
+                cacheStdoutAndStderr: true,
             },
         );
         const { code, time_usage_ms, memory_usage_kb } = res;
         let { status } = res;
-        if (res.files[`${filename}.out`] || !fs.existsSync(stdout)) {
-            fs.writeFileSync(stdout, res.files[`${filename}.out`] || '');
+        let stdout = { fileId: res.fileIds['stdout'] };
+        const stderr = { fileId: res.fileIds['stderr'] };
+        if (res.fileIds[`${filename}.out`]) {
+            stdout = { fileId: res.fileIds[`${filename}.out`] };
         }
         let message: any = '';
         let score = 0;
@@ -71,8 +68,8 @@ function judgeCase(c: Case, sid: string) {
             } else {
                 [status, score, message] = await check({
                     copyIn: ctx.checker.copyIn,
-                    stdin: c.input,
-                    stdout: c.output,
+                    stdin: { src: c.input },
+                    stdout: { src: c.output },
                     user_stdout: stdout,
                     user_stderr: stderr,
                     checker_type: ctx.config.checker_type,
@@ -84,10 +81,9 @@ function judgeCase(c: Case, sid: string) {
             if (code < 32) message = signals[code];
             else message = { message: 'Your program returned {0}.', params: [code] };
         }
-        await Promise.all([
-            fs.remove(stdout),
-            fs.remove(stderr),
-        ]).catch(() => { /* Ignore file doesn't exist */ });
+        await Promise.all(
+            Object.values(res.fileIds).map((id) => del(id)),
+        ).catch(() => { /* Ignore file doesn't exist */ });
         if (runner && ctx.rerun && status === STATUS.STATUS_TIME_LIMIT_EXCEEDED) {
             ctx.rerun--;
             await runner(ctx, ctxSubtask);

--- a/packages/hydrojudge/src/judge/hack.ts
+++ b/packages/hydrojudge/src/judge/hack.ts
@@ -97,10 +97,10 @@ export const judge = async (ctx: Context) => {
         } else {
             [status, , message] = await check({
                 copyIn: copyInDir(path.resolve(ctx.tmpdir, 'checker')),
-                stdin: input,
-                stdout,
-                user_stdout: stdout,
-                user_stderr: stderr,
+                stdin: { src: input },
+                stdout: { src: stdout },
+                user_stdout: { src: stdout },
+                user_stderr: { src: stderr },
                 checker_type: ctx.config.checker_type,
                 score: 100,
                 detail: ctx.config.detail,


### PR DESCRIPTION
- 加入二进制输出和对比支持。实现方式为在沙箱服务端缓存输出文件用于之后的对比
- 另外把 `run` 和 `runMultiple` 拆开