### PR TITLE
elastic: use term op instead of match

### DIFF
--- a/packages/elastic/script.ts
+++ b/packages/elastic/script.ts
@@ -49,7 +49,7 @@ global.Hydro.lib.problemSearch = async (domainId, q, opts) => {
         post_filter: {
             bool: {
                 minimum_should_match: 1,
-                should: domainIds.map((i) => ({ match: { domainId: i } })),
+                should: domainIds.map((i) => ({ term: { domainId: i } })),
             },
         },
     });
@@ -64,7 +64,7 @@ export const description = 'Elastic problem search re-index';
 
 export async function run({ domainId }, report) {
     try {
-        if (domainId) await client.deleteByQuery({ index: 'problem', query: { match: { domainId } } });
+        if (domainId) await client.deleteByQuery({ index: 'problem', query: { term: { domainId } } });
         else await client.deleteByQuery({ index: 'problem', query: { match_all: {} } });
     } catch (e) {
         if (!e.message.includes('index_not_found_exception')) throw e;


### PR DESCRIPTION
> The term query does not analyze the search term. The term query only searches for the exact term you provide.

`term` 与 `match` 的区别在于 `term` 不会进行分析（分词），在改动处显然是不应该使用 `match` 的。尤其是删除处甚至可能删除掉别的域的 index