### PR TITLE
fix: vjudge can't get latest problems

### DIFF
--- a/packages/vjudge/src/interface.ts
+++ b/packages/vjudge/src/interface.ts
@@ -9,6 +9,7 @@ export interface RemoteAccount {
     query?: string;
     frozen?: string;
     problemLists?: string[];
+    page: number;
 }
 declare module 'hydrooj/src/interface' {
     interface Collections {

--- a/packages/vjudge/src/model.ts
+++ b/packages/vjudge/src/model.ts
@@ -55,6 +55,11 @@ class Service {
 
     async sync(domainId: string, resync = false, list: string) {
         let page = 1;
+        if (domainId !== 'codeforces') {
+            const oj = await coll.findOne({ type: domainId });
+            page = oj.page;
+            resync = false;
+        }
         let pids = await this.api.listProblem(page, resync, list);
         while (pids.length) {
             logger.info(`${domainId}: Syncing page ${page}`);
@@ -86,6 +91,10 @@ class Service {
             }
             page++;
             pids = await this.api.listProblem(page, resync, list);
+        }
+        page--;
+        if (domainId !== 'codeforces') {
+            coll.updateMany({ type: domainId }, { $set: { page } });
         }
     }
 


### PR DESCRIPTION
目前的逻辑中，除codeforces以外的vjudge在启动oj时均无法正确获取最新题目，该方案给vjudge添加page字段解决此问题