### PR TITLE
ci: always build ui-default when not published

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           .github/workflows/**
     - name: Build And Lint
       run: |
-        if [[ ${{ steps.ui-changed-files.outputs.any_changed }} == true ]]
+        if [[ ${{ steps.ui-changed-files.outputs.any_changed }} == true ]] || [[ $(npm info @hydrooj/ui-default version) != $(node -e 'console.log(require("./packages/ui-default/package.json").version)') ]]
         then
           yarn build:ui:gulp
           parallel --tty -j+0 yarn ::: lint:ci lint:ui:ci build build:ui:production:webpack test


### PR DESCRIPTION
Always build `@hydrooj/ui-default` when the current version has not been published to [npm registry](https://www.npmjs.com/package/@hydrooj/ui-default).

See also: #384