### PR TITLE
ui: perfect allow admin view contest problem

### DIFF
--- a/packages/hydrooj/package.json
+++ b/packages/hydrooj/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hydrooj",
-    "version": "3.16.0",
+    "version": "3.16.1",
     "bin": "bin/hydrooj.js",
     "main": "src/loader",
     "module": "src/loader",

--- a/packages/hydrooj/src/handler/contest.ts
+++ b/packages/hydrooj/src/handler/contest.ts
@@ -127,7 +127,7 @@ export class ContestDetailHandler extends ContestDetailBaseHandler {
                 .replace(/="file:\/\//g, `="./${this.tdoc.docId}/file/`);
         }
         if (
-            (contest.isNotStarted(this.tdoc) || !this.tsdoc?.attend)
+            (contest.isNotStarted(this.tdoc) || (!this.tsdoc?.attend && !contest.isDone(this.tdoc)))
             && !this.user.own(this.tdoc)
             && !this.user.hasPerm(PERM.PERM_VIEW_CONTEST_HIDDEN_SCOREBOARD)
         ) return;

--- a/packages/hydrooj/src/handler/homework.ts
+++ b/packages/hydrooj/src/handler/homework.ts
@@ -74,7 +74,7 @@ class HomeworkDetailHandler extends Handler {
             tdoc, tsdoc, udict, ddocs, page, dpcount, dcount,
         };
         if (
-            (contest.isNotStarted(tdoc) || !tsdoc?.attend)
+            (contest.isNotStarted(tdoc) || (!tsdoc?.attend && !contest.isDone(tdoc)))
             && !this.user.own(tdoc)
             && !this.user.hasPerm(PERM.PERM_VIEW_HOMEWORK_HIDDEN_SCOREBOARD)
         ) return;

--- a/packages/ui-default/package.json
+++ b/packages/ui-default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hydrooj/ui-default",
-  "version": "4.39.9",
+  "version": "4.39.10",
   "author": "undefined <i@undefined.moe>",
   "license": "AGPL-3.0",
   "main": "hydro.js",

--- a/packages/ui-default/templates/contest_detail.html
+++ b/packages/ui-default/templates/contest_detail.html
@@ -61,6 +61,8 @@
             </tr>
           </thead>
           <tbody>
+          {% set isAdmin = handler.user.own(tdoc) or handler.user.hasPerm(perm.PERM_VIEW_CONTEST_HIDDEN_SCOREBOARD) %}
+          {% set ntdoc = model.contest.isDone(tdoc) or (tsdoc.attend and not model.contest.isNotStarted(tdoc)) %}
           {%- for pid in tdoc.pids -%}
             <tr>
             {% if handler.user.hasPriv(PRIV.PRIV_USER_PROFILE) %}
@@ -78,12 +80,8 @@
               {% endif %}
             {% endif %}
               <td class="col--problem col--problem-name">
-                {% if not tsdoc.attend and (handler.user.own(tdoc) or handler.user.hasPerm(perm.PERM_VIEW_CONTEST_HIDDEN_SCOREBOARD)) %}
-                  {% if model.contest.isDone(tdoc) or (tsdoc.attend and not model.contest.isNotStarted(tdoc)) %}
-                    {{ problem.render_problem_title(pdict[pid], tdoc=tdoc, show_invisible_flag=false, show_tags=false) }}
-                  {% else %}
+                {% if isAdmin and not ntdoc %}
                     {{ problem.render_problem_title(pdict[pid], show_invisible_flag=false, show_tags=false) }}
-                  {% endif %}
                 {% else %}
                   {{ problem.render_problem_title(pdict[pid], tdoc=tdoc, show_invisible_flag=false, show_tags=false) }}
                 {% endif %}

--- a/packages/ui-default/templates/contest_detail.html
+++ b/packages/ui-default/templates/contest_detail.html
@@ -81,7 +81,7 @@
             {% endif %}
               <td class="col--problem col--problem-name">
                 {% if isAdmin and not ntdoc %}
-                    {{ problem.render_problem_title(pdict[pid], show_invisible_flag=false, show_tags=false) }}
+                  {{ problem.render_problem_title(pdict[pid], show_invisible_flag=false, show_tags=false) }}
                 {% else %}
                   {{ problem.render_problem_title(pdict[pid], tdoc=tdoc, show_invisible_flag=false, show_tags=false) }}
                 {% endif %}

--- a/packages/ui-default/templates/contest_detail.html
+++ b/packages/ui-default/templates/contest_detail.html
@@ -78,8 +78,12 @@
               {% endif %}
             {% endif %}
               <td class="col--problem col--problem-name">
-                {% if model.contest.isNotStarted(tdoc) %}
-                  {{ problem.render_problem_title(pdict[pid], show_invisible_flag=false, show_tags=false) }}
+                {% if not tsdoc.attend and (handler.user.own(tdoc) or handler.user.hasPerm(perm.PERM_VIEW_CONTEST_HIDDEN_SCOREBOARD)) %}
+                  {% if model.contest.isDone(tdoc) or (tsdoc.attend and not model.contest.isNotStarted(tdoc)) %}
+                    {{ problem.render_problem_title(pdict[pid], tdoc=tdoc, show_invisible_flag=false, show_tags=false) }}
+                  {% else %}
+                    {{ problem.render_problem_title(pdict[pid], show_invisible_flag=false, show_tags=false) }}
+                  {% endif %}
                 {% else %}
                   {{ problem.render_problem_title(pdict[pid], tdoc=tdoc, show_invisible_flag=false, show_tags=false) }}
                 {% endif %}

--- a/packages/ui-default/templates/homework_detail.html
+++ b/packages/ui-default/templates/homework_detail.html
@@ -56,7 +56,7 @@
               {% endif %}
               <td class="col--problem col--problem-name">
                 {% if isAdmin and not ntdoc %}
-                    {{ problem.render_problem_title(pdict[pid], show_invisible_flag=false, show_tags=false) }}
+                  {{ problem.render_problem_title(pdict[pid], show_invisible_flag=false, show_tags=false) }}
                 {% else %}
                   {{ problem.render_problem_title(pdict[pid], tdoc=tdoc, show_invisible_flag=false, show_tags=false) }}
                 {% endif %}

--- a/packages/ui-default/templates/homework_detail.html
+++ b/packages/ui-default/templates/homework_detail.html
@@ -53,8 +53,12 @@
                 {% endif %}
               {% endif %}
               <td class="col--problem col--problem-name">
-                {% if model.contest.isNotStarted(tdoc) %}
-                  {{ problem.render_problem_title(pdict[pid], show_invisible_flag=false, show_tags=false) }}
+                {% if handler.user.own(tdoc) or handler.user.hasPerm(perm.PERM_VIEW_HOMEWORK_HIDDEN_SCOREBOARD) %}
+                  {% if model.contest.isDone(tdoc) or (tsdoc.attend and not model.contest.isNotStarted(tdoc)) %}
+                    {{ problem.render_problem_title(pdict[pid], tdoc=tdoc, show_invisible_flag=false, show_tags=false) }}
+                  {% else %}
+                    {{ problem.render_problem_title(pdict[pid], show_invisible_flag=false, show_tags=false) }}
+                  {% endif %}
                 {% else %}
                   {{ problem.render_problem_title(pdict[pid], tdoc=tdoc, show_invisible_flag=false, show_tags=false) }}
                 {% endif %}

--- a/packages/ui-default/templates/homework_detail.html
+++ b/packages/ui-default/templates/homework_detail.html
@@ -36,6 +36,8 @@
             </tr>
           </thead>
           <tbody>
+          {% set isAdmin = handler.user.own(tdoc) or handler.user.hasPerm(perm.PERM_VIEW_HOMEWORK_HIDDEN_SCOREBOARD) %}
+          {% set ntdoc = model.contest.isDone(tdoc) or (tsdoc.attend and not model.contest.isNotStarted(tdoc)) %}
           {%- for pid in tdoc.pids -%}
             <tr>
               {% if handler.user.hasPriv(PRIV.PRIV_USER_PROFILE) %}
@@ -53,12 +55,8 @@
                 {% endif %}
               {% endif %}
               <td class="col--problem col--problem-name">
-                {% if handler.user.own(tdoc) or handler.user.hasPerm(perm.PERM_VIEW_HOMEWORK_HIDDEN_SCOREBOARD) %}
-                  {% if model.contest.isDone(tdoc) or (tsdoc.attend and not model.contest.isNotStarted(tdoc)) %}
-                    {{ problem.render_problem_title(pdict[pid], tdoc=tdoc, show_invisible_flag=false, show_tags=false) }}
-                  {% else %}
+                {% if isAdmin and not ntdoc %}
                     {{ problem.render_problem_title(pdict[pid], show_invisible_flag=false, show_tags=false) }}
-                  {% endif %}
                 {% else %}
                   {{ problem.render_problem_title(pdict[pid], tdoc=tdoc, show_invisible_flag=false, show_tags=false) }}
                 {% endif %}


### PR DESCRIPTION
In the previous logic, the administrator still needs to participate in the contest or homework to view the problems details after the contest or homework starts, but in many cases, the administrator will not participate in his own contest or homework