### PR TITLE
vjudge: fix poj chaotic content and missing image

### DIFF
--- a/packages/vjudge/package.json
+++ b/packages/vjudge/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hydrooj/vjudge",
-    "version": "1.5.0-next.13",
+    "version": "1.5.0-next.14",
     "description": "Submit problems to remote oj",
     "main": "package.json",
     "repository": "https://github.com/hydro-dev/Hydro.git",

--- a/packages/vjudge/src/providers/poj.ts
+++ b/packages/vjudge/src/providers/poj.ts
@@ -73,7 +73,7 @@ export default class POJProvider implements IBasicProvider {
 
     get(url: string) {
         logger.debug('get', url);
-        if (!url.includes('//')) url = `${this.account.endpoint || 'http://poj.org'}${url}`;
+        if (!url.startsWith('http')) url = new URL(url, this.account.endpoint || 'http://poj.org').toString();
         const req = superagent.get(url).set('Cookie', this.cookie);
         if (this.account.proxy) return req.proxy(this.account.proxy);
         return req;
@@ -138,10 +138,7 @@ export default class POJProvider implements IBasicProvider {
             content.children[0].remove();
             content.children[0].remove();
             content.querySelectorAll('img[src]').forEach((ele) => {
-                let src = ele.getAttribute('src');
-                if (!src.startsWith('http')) {
-                    src = new URL(src, 'http://poj.org/').toString();
-                }
+                const src = ele.getAttribute('src');
                 if (images[src]) {
                     ele.setAttribute('src', `file://${images[src]}.png`);
                     return;

--- a/packages/vjudge/src/providers/poj.ts
+++ b/packages/vjudge/src/providers/poj.ts
@@ -138,8 +138,10 @@ export default class POJProvider implements IBasicProvider {
             content.children[0].remove();
             content.children[0].remove();
             content.querySelectorAll('img[src]').forEach((ele) => {
-                const src = ele.getAttribute('src');
-                if (!src.startsWith('http')) return;
+                let src = ele.getAttribute('src');
+                if (!src.startsWith('http')) {
+                    src = new URL(src, 'http://poj.org/').toString();
+                }
                 if (images[src]) {
                     ele.setAttribute('src', `file://${images[src]}.png`);
                     return;
@@ -167,15 +169,11 @@ export default class POJProvider implements IBasicProvider {
                 } else if (node.className.includes('sio')) {
                     html += `<pre><code class="language-${markNext}${lastId}">${htmlEncode(node.innerHTML)}</code></pre>`;
                 } else if (node.className.includes('ptx')) {
-                    for (const item of node.childNodes) {
-                        if (item.nodeType === 3) {
-                            const p = page.createElement('p');
-                            p.innerHTML = htmlEncode(item.textContent);
-                            item.replaceWith(p);
-                        }
-                        if (item.nodeName.includes('BR')) item.remove();
+                    for (const item of node.innerHTML.split('\n<br>\n<br>')) {
+                        const p = page.createElement('p');
+                        p.innerHTML = item.trim();
+                        html += p.outerHTML; 
                     }
-                    html += node.innerHTML;
                 } else html += node.innerHTML;
             }
             contents[langs[lang]] = html;

--- a/packages/vjudge/src/providers/poj.ts
+++ b/packages/vjudge/src/providers/poj.ts
@@ -172,7 +172,7 @@ export default class POJProvider implements IBasicProvider {
                     for (const item of node.innerHTML.split('\n<br>\n<br>')) {
                         const p = page.createElement('p');
                         p.innerHTML = item.trim();
-                        html += p.outerHTML; 
+                        html += p.outerHTML;
                     }
                 } else html += node.innerHTML;
             }


### PR DESCRIPTION
现有逻辑下poj的vjudge导入的题面排版混乱，并且丢失题目图片，如下所示：

现有逻辑导入的题面：
![image](https://user-images.githubusercontent.com/46668943/189280281-f9efefc5-a70f-4dab-93a8-2bc4a5cf7cb1.png)

修复后导入的题面：
![image](https://user-images.githubusercontent.com/46668943/189280367-d0226133-5ed6-4167-8ce9-bf8f0def1de0.png)

现有逻辑丢失图片：
![image](https://user-images.githubusercontent.com/46668943/189280413-f870ffc2-5305-4bed-92b3-4d6e59c1c9e3.png)

修复后正确下载图片：
![image](https://user-images.githubusercontent.com/46668943/189280455-beed9791-fa2b-45f4-b56f-2c583ed2d87e.png)

