### PR TITLE
vjudge: fix poj content

### DIFF
--- a/packages/vjudge/package.json
+++ b/packages/vjudge/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hydrooj/vjudge",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "description": "Submit problems to remote oj",
     "main": "package.json",
     "repository": "https://github.com/hydro-dev/Hydro.git",

--- a/packages/vjudge/src/providers/poj.ts
+++ b/packages/vjudge/src/providers/poj.ts
@@ -59,9 +59,7 @@ poj.6:
 
 const langs = {
     default: 'en',
-    'zh-CN': 'zh_CN',
-    es: 'es',
-    ja: 'ja',
+    'zh-CN': 'zh',
 };
 
 export default class POJProvider implements IBasicProvider {
@@ -191,13 +189,15 @@ export default class POJProvider implements IBasicProvider {
                     for (const item of node.innerHTML.split('\n<br>')) {
                         if (item !== '') {
                             const p = page.createElement('p');
-                            p.innerHTML = item.trim().replace(/\$/g, '\\$');
+                            p.innerHTML = item.trim().replace(/\$/g, '<span>$</span>');
                             html += p.outerHTML;
                         }
                     }
                 } else html += node.innerHTML;
             }
-            contents[langs[lang]] = html;
+            if (lang in langs) {
+                contents[langs[lang]] = html;
+            }
         }
         return {
             title: main.getElementsByClassName('ptt')[0].innerHTML,

--- a/packages/vjudge/src/providers/poj.ts
+++ b/packages/vjudge/src/providers/poj.ts
@@ -129,6 +129,7 @@ export default class POJProvider implements IBasicProvider {
         const memory = info.children[2].innerHTML.split('</b> ')[1].toLowerCase().trim();
         const contents = {};
         const images = {};
+        let tag = '';
         for (const lang of languages) {
             await sleep(1000);
             const { text } = await this.get(`/problem?id=${id.split('P')[1]}&lang=${lang}&change=true`);
@@ -157,6 +158,10 @@ export default class POJProvider implements IBasicProvider {
                 if (node.className.includes('pst')) {
                     if (!node.innerHTML.startsWith('Sample ')) {
                         html += `<h2>${htmlEncode(node.innerHTML)}</h2>`;
+                        if (node.textContent === 'Source') {
+                            tag = node.nextElementSibling.textContent.trim();
+                            node.nextElementSibling.innerHTML = tag;
+                        }
                     } else if (node.innerHTML.startsWith('Sample Input')) {
                         lastId++;
                         markNext = 'input';
@@ -164,12 +169,31 @@ export default class POJProvider implements IBasicProvider {
                         markNext = 'output';
                     }
                 } else if (node.className.includes('sio')) {
-                    html += `<pre><code class="language-${markNext}${lastId}">${htmlEncode(node.innerHTML)}</code></pre>`;
+                    html += `\n\n<pre><code class="language-${markNext}${lastId}">${node.innerHTML}</code></pre>\n\n`;
                 } else if (node.className.includes('ptx')) {
-                    for (const item of node.innerHTML.split('\n<br>\n<br>')) {
-                        const p = page.createElement('p');
-                        p.innerHTML = item.trim();
-                        html += p.outerHTML;
+                    for (const primaryTd of node.querySelectorAll('td')) {
+                        const td = page.createElement('td');
+                        td.textContent = primaryTd.textContent;
+                        if (primaryTd.colSpan > 1) td.colSpan = primaryTd.colSpan;
+                        primaryTd.replaceWith(td);
+                    }
+                    for (const primaryPre of node.querySelectorAll('pre')) {
+                        const pre = page.createElement('pre');
+                        for (const inner of primaryPre.innerHTML.split('<br>')) {
+                            if (inner !== '') {
+                                const preP = page.createElement('p');
+                                preP.innerHTML = inner;
+                                pre.append(preP);
+                            }
+                        }
+                        primaryPre.replaceWith(pre);
+                    }
+                    for (const item of node.innerHTML.split('\n<br>')) {
+                        if (item !== '') {
+                            const p = page.createElement('p');
+                            p.innerHTML = item.trim().replace(/\$/g, '\\$');
+                            html += p.outerHTML;
+                        }
                     }
                 } else html += node.innerHTML;
             }
@@ -181,7 +205,7 @@ export default class POJProvider implements IBasicProvider {
                 'config.yaml': Buffer.from(`time: ${time}\nmemory: ${memory}\ntype: remote_judge\nsubType: poj\ntarget: ${id}`),
             },
             files,
-            tag: [],
+            tag: [tag],
             content: JSON.stringify(contents),
         };
     }


### PR DESCRIPTION
修复问题①：source带无效超链接。解决方式：去除source超链接，并将source的内容送入tag，tag效果如图
![image](https://user-images.githubusercontent.com/46668943/189490939-49fa0710-eec5-453f-bf6d-81e26d02b650.png)

修复问题②：之前使用 `split('\n<br>\n<br>')` ，会导致poj使用了 `<center>` 标签的图片的后续文字排版错乱，已经替换split内容

修复前：
![JKNKIC7 6YK(G~944_HR417](https://user-images.githubusercontent.com/46668943/189491043-1d6a3446-4a69-4abb-9fde-b5ae2447ef30.png)

修复后：
![U5DD1A)A5S300CD5U4AE1NH](https://user-images.githubusercontent.com/46668943/189491052-ef0974f8-57ff-4d7e-a87a-01274ea79f42.png)

修复问题③：由于poj题面（非sample）的 `<pre>` 标签里也有 `<br>`，会被上一步逻辑导致题面错乱，因此需要先处理pre内的br
修复前：
![A98EB939FF@O3_TS4~UE8CL](https://user-images.githubusercontent.com/46668943/189491319-380445e5-ff1d-4024-98d7-c6233528bc90.png)

修复后：
![ZL3I9%OS}F0JT6$(ZXXYIJH](https://user-images.githubusercontent.com/46668943/189491329-bdd87480-0321-426a-a8d8-e9999d097ffd.png)


修复问题④：修复poj的table错乱问题，由于poj table书写不规范，于是对innerHTML重组

修复前：
![W% @$(}15A_L(MEJRS90@8L](https://user-images.githubusercontent.com/46668943/189491103-32547f5e-2ae3-42d7-adf7-73f8ad7a715a.png)

修复后：
![NZVGKH(1RG02Q{1C`BROR2P](https://user-images.githubusercontent.com/46668943/189491118-6eff17c0-1e65-4a12-8ffd-12536cdf1eb9.png)

修复问题⑤：由于poj不支持LaTeX或katex，因此美元符号在poj仅为美元的意思，需使用 `\` 防止hydro自动识别为数学公式，其次sample内容不需要htmlencode

美元符号修复前：
![CUD1O_MJ% 23R5)L%AW(NE3](https://user-images.githubusercontent.com/46668943/189491218-3c3ef75e-ff8e-4644-989c-7e0293d2758a.png)

美元符号修复后：
![G_E@Z9{0MWF5VKG1H_G(E)L](https://user-images.githubusercontent.com/46668943/189491227-4cee2e45-8ae3-4e61-91e2-419fa3f84cca.png)

去除htmlencode前：
![23VXAG ARNX }IIT%6%GUL9](https://user-images.githubusercontent.com/46668943/189491249-beb4e005-b3ef-4684-b161-1648e462a85f.png)

去除htmlencode后：
![7QTQK(@%QZ@P9M(7F9 UMBN](https://user-images.githubusercontent.com/46668943/189491261-539d0fe2-0537-481d-bc97-63e961fb071f.png)

