### PR TITLE
fix(core): add PRIV_UNLIMITED_ACCESS to default permissions for judge user

### DIFF
--- a/packages/hydrooj/src/model/user.ts
+++ b/packages/hydrooj/src/model/user.ts
@@ -418,7 +418,7 @@ class UserModel {
         return await UserModel.setPriv(
             uid,
             PRIV.PRIV_USER_PROFILE | PRIV.PRIV_JUDGE | PRIV.PRIV_VIEW_ALL_DOMAIN
-            | PRIV.PRIV_READ_PROBLEM_DATA,
+            | PRIV.PRIV_READ_PROBLEM_DATA | PRIV.PRIV_UNLIMITED_ACCESS,
         );
     }
 


### PR DESCRIPTION
当评测账号没有 `PRIV_UNLIMITED_ACCESS` 权限时，对于数据较多的题目会报操作次数过多错误（`OpcountExceededError`），导致评测失败