### PR TITLE
Add fake-cf

### DIFF
--- a/packages/hydrooj/src/model/contest.ts
+++ b/packages/hydrooj/src/model/contest.ts
@@ -507,8 +507,8 @@ const fakecf = buildContestRule({
     check: () => { },
     submitAfterAccept: true,
     showScoreboard: (tdoc, now) => now > tdoc.beginAt,
-    showSelfRecord: (tdoc, now) => now > tdoc.endAt,
-    showRecord: (tdoc, now) => now > new Date(tdoc.endAt.setHours(tdoc.endAt.getHours()+1)),
+    showSelfRecord: (tdoc, now) => now > new Date(tdoc.endAt.setHours(tdoc.endAt.getHours()+5)),
+    showRecord: (tdoc, now) => now > new Date(tdoc.endAt.setHours(tdoc.endAt.getHours()+5)),
     stat(tdoc, journal) {
         const ntry = Counter<number>();
         const detail = {};

--- a/packages/hydrooj/src/model/contest.ts
+++ b/packages/hydrooj/src/model/contest.ts
@@ -512,21 +512,17 @@ const fakecf = buildContestRule({
     stat(tdoc, journal) {
         const ntry = Counter<number>();
         const detail = {};
-        const len = tdoc.endAt.getTime() - tdoc.beginAt.getTime();
-        const subtasks: Record<number, SubtaskResult> = {};
         const now = new Date();
         for (const j of journal.filter((i) => tdoc.pids.includes(i.pid))) {
             const valid = !([STATUS.STATUS_COMPILE_ERROR, STATUS.STATUS_FORMAT_ERROR].includes(j.status)) && j.subtasks[1]?.status == STATUS.STATUS_ACCEPTED;
             if (!valid) continue;
-            console.log('pid: %d, a:%d',j.pid,j.subtasks[1].status);
             const real = Math.round((j.rid.getTimestamp().getTime() - tdoc.beginAt.getTime())/60000);
             const subtaskId = now.getTime() <= tdoc.endAt.getTime() ? 2 : 3;
             const sub = j.subtasks[subtaskId];
-            if (sub == null || sub == undefined) continue;
+            if (sub == null) continue;
             const score = j.subtasks[1].score * 100;
             const penaltyScore = Math.round(sub.score > 0 ? score - real * score / 250 - (ntry[j.pid] - 1) * 10 : 0);
             ntry[j.pid] += sub.score > 0 ? 0 : 1;
-            console.log("score: {0} status: {1}".format(penaltyScore,now.getTime() <= tdoc.endAt.getTime()));
             detail[j.pid] = {
                 ...j,
                 status: sub.status,
@@ -559,7 +555,7 @@ const fakecf = buildContestRule({
         }
         row.push({
             type: 'total_score',
-            value: `${Math.round(tsdoc.score)}` || '0',
+            value: `${Math.round(tsdoc.score) || 0}`,
             hover: '',
         });
         for (const pid of tdoc.pids) {


### PR DESCRIPTION
这是一个简易版的 CF 赛制。

##### features:

- 配置数据时开 3 个计分方式为 `min` 的 subtask，分别放 samples, pretests, system tests。

- 每个 subtask 分值均设为总分 / 100。

- 比赛中，选手无法看到自己的记录，但是可以在榜单 hover 上看到最后一次提交的 verdict。

- CE/挂样例 不计入提交次数和罚时，计分方式与 CF 相同。

- 如果要搞 Hack 也许可以赛后导出所有 AC 代码然后让选手私下把 Hack 发给主持人？

- 赛后加强完 system test 后可以 rejudge 一下。

- 结束 5h 后开放所有记录。