### PR TITLE
core: match jp testdata file name

### DIFF
--- a/packages/utils/lib/common.ts
+++ b/packages/utils/lib/common.ts
@@ -262,6 +262,16 @@ const SubtaskMatcher: MatchRule[] = [
         preferredScorerType: 'sum',
     },
     {
+        regex: /^(([0-9]+)(?:[^\d]*))\.in$/,
+        output: [
+            (a) => `${a[1]}.out`,
+            (a) => `${a[1]}.ans`,
+        ],
+        id: (a) => +a[2],
+        subtask: () => 1,
+        preferredScorerType: 'sum',
+    },
+    {
         regex: /^([^\d]*)([0-9]+)([-_])([0-9]+)\.in$/,
         output: [
             (a) => `${a[1]}${a[2]}${a[3]}${a[4]}.out`,

--- a/packages/utils/lib/common.ts
+++ b/packages/utils/lib/common.ts
@@ -262,7 +262,7 @@ const SubtaskMatcher: MatchRule[] = [
         preferredScorerType: 'sum',
     },
     {
-        regex: /^(([0-9]+)(?:[^\d]*))\.in$/,
+        regex: /^(([0-9]+)[-_](?:.*))\.in$/,
         output: [
             (a) => `${a[1]}.out`,
             (a) => `${a[1]}.ans`,


### PR DESCRIPTION
support filename like:
 - ([0-9]+)-xxxxx.in
 - ([0-9]+)_xxxxx.in

example:
 - 1_100000_0.in
 - 2_100000_0.in
 - 01-one.in
 - 36-random.in
 - 01-one-cube.in