### PR TITLE
ui: fix problem export

### DIFF
--- a/packages/ui-default/templates/problem_main.html
+++ b/packages/ui-default/templates/problem_main.html
@@ -43,13 +43,15 @@
                 <span class="icon icon-check"></span>
                 {{ _('Unhide Selected') }}
               </a>
-              <a href="javascript:;" class="menu__link display-mode-hide" name="download_selected_problems">
-                <span class="icon icon-download"></span>
-                {{ _('Download Selected') }}
-              </a>
               <a href="javascript:;" class="menu__link display-mode-hide" name="delete_selected_problems">
                 <span class="icon icon-delete"></span>
                 {{ _('Remove Selected') }}
+              </a>
+            {% endif %}
+            {% if handler.user.hasPerm(perm.PERM_READ_PROBLEM_DATA) %}
+              <a href="javascript:;" class="menu__link display-mode-hide" name="download_selected_problems">
+                <span class="icon icon-download"></span>
+                {{ _('Download Selected') }}
               </a>
             {% endif %}
             <a href="javascript:;" class="menu__link display-mode-hide" name="copy_selected_problems">


### PR DESCRIPTION
There is a bug: if user has `PERM_READ_PROBLEM_DATA` but no `PERM_EDIT_PROBLEM`, he can't export problems in `problem_main` page.