### PR TITLE
vjudge: add hduoj

### DIFF
--- a/packages/vjudge/src/providers/hduoj.ts
+++ b/packages/vjudge/src/providers/hduoj.ts
@@ -67,8 +67,12 @@ export default class HDUOJProvider extends BasicFetcher implements IBasicProvide
         const ProblemMatcher = /p\(\d,(\d+),\d,".+?",\d+,\d+\);/g;
         if (resync && page > 1) return [];
         const { text } = await this.get(`/listproblem.php?vol=${page}`);
-        let match, result = [];
-        while (match = ProblemMatcher.exec(text)) result.push(`P${match[1]}`);
+        let result = [];
+        let match = ProblemMatcher.exec(text);
+        while (match) {
+            result.push(`P${match[1]}`);
+            match = ProblemMatcher.exec(text);
+        }
         return result;
     }
 

--- a/packages/vjudge/src/providers/hduoj.ts
+++ b/packages/vjudge/src/providers/hduoj.ts
@@ -1,12 +1,15 @@
 import { JSDOM } from 'jsdom';
-import { Logger, STATUS, sleep, parseTimeMS, parseMemoryMB } from 'hydrooj';
+import {
+    Logger, STATUS, sleep,
+    parseTimeMS, parseMemoryMB
+} from 'hydrooj';
 import { BasicFetcher } from '../fetch';
 import { IBasicProvider, RemoteAccount } from '../interface';
 
 const logger = new Logger('remote/hduoj');
 const statusDict = {
-    'Queuing': STATUS.STATUS_JUDGING,
-    'Accepted': STATUS.STATUS_ACCEPTED,
+    Queuing: STATUS.STATUS_JUDGING,
+    Accepted: STATUS.STATUS_ACCEPTED,
     'Wrong Answer': STATUS.STATUS_WRONG_ANSWER,
     'Presentation Error': STATUS.STATUS_WRONG_ANSWER,
     'Compilation Error': STATUS.STATUS_COMPILE_ERROR,
@@ -61,9 +64,9 @@ export default class HDUOJProvider extends BasicFetcher implements IBasicProvide
 
     async listProblem(page: number, resync = false) {
         const ProblemMatcher = /p\(\d,(\d+),\d,".+?",\d+,\d+\);/g;
-        // if (resync && page > 1) return [];
+        if (resync && page > 1) return [];
         const { text } = await this.get(`/listproblem.php?vol=${page}`);
-        var match, result = new Array();
+        let match, result = [];
         while (match = ProblemMatcher.exec(text)) result.push(`P${match[1]}`);
         return result;
     }
@@ -78,6 +81,7 @@ export default class HDUOJProvider extends BasicFetcher implements IBasicProvide
                 language,
                 _usercode: new Buffer(encodeURIComponent(source)).toString('base64')
             });
+        const { window: { document } } = new JSDOM(text);
         var rid = /<td height=22px>(\d+)<\/td>/g.exec(text);
         if (!rid) {
             end({ status: STATUS.STATUS_SYSTEM_ERROR, message: 'Submit Failed' });

--- a/packages/vjudge/src/providers/hduoj.ts
+++ b/packages/vjudge/src/providers/hduoj.ts
@@ -1,7 +1,7 @@
 import { JSDOM } from 'jsdom';
 import {
     Logger, STATUS, sleep,
-    parseTimeMS, parseMemoryMB
+    parseTimeMS, parseMemoryMB,
 } from 'hydrooj';
 import { BasicFetcher } from '../fetch';
 import { IBasicProvider, RemoteAccount } from '../interface';
@@ -79,15 +79,10 @@ export default class HDUOJProvider extends BasicFetcher implements IBasicProvide
                 check: 0,
                 problemid: id.split('P')[1],
                 language,
-                _usercode: new Buffer(encodeURIComponent(source)).toString('base64')
+                _usercode: Buffer.from(encodeURIComponent(source)).toString('base64'),
             });
         const { window: { document } } = new JSDOM(text);
-        var rid = /<td height=22px>(\d+)<\/td>/g.exec(text);
-        if (!rid) {
-            end({ status: STATUS.STATUS_SYSTEM_ERROR, message: 'Submit Failed' });
-            return null;
-        }
-        return rid[1];
+        return document.querySelector('#fixed_table>table>tbody>tr:nth-child(3)>td:nth-child(1)').innerHTML;
     }
 
     async getCompilerText(id: string) {

--- a/packages/vjudge/src/providers/hduoj.ts
+++ b/packages/vjudge/src/providers/hduoj.ts
@@ -1,8 +1,7 @@
 /* eslint-disable no-await-in-loop */
 import { JSDOM } from 'jsdom';
 import {
-    Logger, STATUS, sleep,
-    parseTimeMS, parseMemoryMB,
+    Logger, parseMemoryMB, parseTimeMS, sleep, STATUS,
 } from 'hydrooj';
 import { BasicFetcher } from '../fetch';
 import { IBasicProvider, RemoteAccount } from '../interface';
@@ -67,7 +66,7 @@ export default class HDUOJProvider extends BasicFetcher implements IBasicProvide
         const ProblemMatcher = /p\(\d,(\d+),\d,".+?",\d+,\d+\);/g;
         if (resync && page > 1) return [];
         const { text } = await this.get(`/listproblem.php?vol=${page}`);
-        let result = [];
+        const result = [];
         let match = ProblemMatcher.exec(text);
         while (match) {
             result.push(`P${match[1]}`);

--- a/packages/vjudge/src/providers/hduoj.ts
+++ b/packages/vjudge/src/providers/hduoj.ts
@@ -58,12 +58,12 @@ export default class HDUOJProvider extends BasicFetcher implements IBasicProvide
         contentNode.querySelector('center').remove();
         contentNode.querySelectorAll('div.panel_title').forEach(title => {
             const ele = document.createElement('h2');
-            ele.innerHTML=title.innerHTML;
+            ele.innerHTML = title.innerHTML;
             title.replaceWith(ele);
         });
         contentNode.querySelectorAll('div.panel_content').forEach(content => {
             const ele = document.createElement('p');
-            ele.innerHTML=content.innerHTML;
+            ele.innerHTML = content.innerHTML;
             content.replaceWith(ele);
         });
         let sampleId = 0;
@@ -71,8 +71,8 @@ export default class HDUOJProvider extends BasicFetcher implements IBasicProvide
             const sampleNode = sample.parentElement.parentElement;
             const title = sampleNode.previousElementSibling;
             let sampleType;
-            if(title.innerHTML=='Sample Input')sampleType='input',++sampleId;
-            else if(title.innerHTML=='Sample Output')sampleType='output';
+            if (title.innerHTML == 'Sample Input') sampleType = 'input', ++sampleId;
+            else if (title.innerHTML == 'Sample Output') sampleType = 'output';
             else return;
             const elePre = document.createElement('pre');
             const eleCode = document.createElement('code');

--- a/packages/vjudge/src/providers/hduoj.ts
+++ b/packages/vjudge/src/providers/hduoj.ts
@@ -108,16 +108,15 @@ export default class HDUOJProvider extends BasicFetcher implements IBasicProvide
             if (status === STATUS.STATUS_JUDGING) continue;
             const time = recordNode.querySelector('td:nth-child(5)').innerHTML;
             const memory = recordNode.querySelector('td:nth-child(6)').innerHTML;
-            const message = {
+            if (status === STATUS.STATUS_COMPILE_ERROR) {
+                await next({ compilerText: await this.getCompilerText(id) });
+            }
+            await end({
                 status,
                 score: status === STATUS.STATUS_ACCEPTED ? 100 : 0,
                 time: parseTimeMS(time),
                 memory: parseMemoryMB(memory) * 1024,
-            };
-            if (status === STATUS.STATUS_COMPILE_ERROR) {
-                message.compilerText = await this.getCompilerText(id);
-            }
-            await end(message);
+            });
             return;
         }
     }

--- a/packages/vjudge/src/providers/hduoj.ts
+++ b/packages/vjudge/src/providers/hduoj.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-await-in-loop */
 import { JSDOM } from 'jsdom';
 import {
     Logger, STATUS, sleep,
@@ -104,14 +105,15 @@ export default class HDUOJProvider extends BasicFetcher implements IBasicProvide
             if (status === STATUS.STATUS_JUDGING) continue;
             const time = recordNode.querySelector('td:nth-child(5)').innerHTML;
             const memory = recordNode.querySelector('td:nth-child(6)').innerHTML;
-            let message = {
+            const message = {
                 status,
                 score: status === STATUS.STATUS_ACCEPTED ? 100 : 0,
                 time: parseTimeMS(time),
                 memory: parseMemoryMB(memory) * 1024,
             };
-            if (status === STATUS.STATUS_COMPILE_ERROR)
+            if (status === STATUS.STATUS_COMPILE_ERROR) {
                 message.compilerText = await this.getCompilerText(id);
+            }
             await end(message);
             return;
         }

--- a/packages/vjudge/src/providers/hduoj.ts
+++ b/packages/vjudge/src/providers/hduoj.ts
@@ -1,0 +1,120 @@
+import { JSDOM } from 'jsdom';
+import { Logger, STATUS, sleep, parseTimeMS, parseMemoryMB } from 'hydrooj';
+import { BasicFetcher } from '../fetch';
+import { IBasicProvider, RemoteAccount } from '../interface';
+
+const logger = new Logger('remote/hduoj');
+const statusDict = {
+    'Queuing': STATUS.STATUS_JUDGING,
+    'Accepted': STATUS.STATUS_ACCEPTED,
+    'Wrong Answer': STATUS.STATUS_WRONG_ANSWER,
+    'Presentation Error': STATUS.STATUS_WRONG_ANSWER,
+    'Compilation Error': STATUS.STATUS_COMPILE_ERROR,
+    'Runtime Error': STATUS.STATUS_RUNTIME_ERROR,
+    'Time Limit Exceeded': STATUS.STATUS_TIME_LIMIT_EXCEEDED,
+    'Memory Limit Exceeded': STATUS.STATUS_MEMORY_LIMIT_EXCEEDED,
+    'Output Limit Exceeded': STATUS.STATUS_OUTPUT_LIMIT_EXCEEDED,
+};
+
+export default class HDUOJProvider extends BasicFetcher implements IBasicProvider {
+    constructor(public account: RemoteAccount, private save: (data: any) => Promise<void>) {
+        super(account, 'https://acm.hdu.edu.cn', 'form', logger);
+    }
+
+    get loggedIn() {
+        return this.get('/').then(({ text: html }) => !html
+            .includes('<form method=post action="/userloginex.php?action=login">'));
+    }
+
+    async ensureLogin() {
+        if (await this.loggedIn) return true;
+        logger.info('retry login');
+        const { header } = await this.get('/');
+        if (header['set-cookie']) {
+            await this.save({ cookie: header['set-cookie'] });
+            this.cookie = header['set-cookie'];
+        }
+        await this.post('/userloginex.php?action=login')
+            .send({
+                username: this.account.handle,
+                userpass: this.account.password,
+                login: 'Sign In',
+            });
+        return this.loggedIn;
+    }
+
+    async getProblem(id: string) {
+        logger.info(id);
+        const res = await this.get(`/showproblem.php?pid=${id.split('P')[1]}`);
+        const { window: { document } } = new JSDOM(res.text);
+        const contentNode = document.querySelector('body>table>tbody>tr:nth-child(4)>td');
+        return {
+            title: contentNode.querySelector('h1').innerHTML,
+            data: {
+                'config.yaml': Buffer.from(`time: ${1000}ms\nmemory: ${1000}k\ntype: remote_judge\nsubType: hduoj\ntarget: ${id}`),
+            },
+            files: {},
+            tag: [],
+            content: contentNode.innerHTML.trim(),
+        };
+    }
+
+    async listProblem(page: number, resync = false) {
+        const ProblemMatcher = /p\(\d,(\d+),\d,".+?",\d+,\d+\);/g;
+        // if (resync && page > 1) return [];
+        const { text } = await this.get(`/listproblem.php?vol=${page}`);
+        var match, result = new Array();
+        while (match = ProblemMatcher.exec(text)) result.push(`P${match[1]}`);
+        return result;
+    }
+
+    async submitProblem(id: string, lang: string, source: string, info, next, end) {
+        await this.ensureLogin();
+        const language = lang.includes('hduoj.') ? lang.split('hduoj.')[1] : '0';
+        const { text } = await this.post('/submit.php?action=submit')
+            .send({
+                check: 0,
+                problemid: id.split('P')[1],
+                language,
+                _usercode: new Buffer(encodeURIComponent(source)).toString('base64')
+            });
+        var rid = /<td height=22px>(\d+)<\/td>/g.exec(text);
+        if (!rid) {
+            end({ status: STATUS.STATUS_SYSTEM_ERROR, message: 'Submit Failed' });
+            return null;
+        }
+        return rid[1];
+    }
+
+    async getCompilerText(id: string) {
+        const { text } = await this.get(`/viewerror.php?rid=${id}`);
+        const { window: { document } } = new JSDOM(text);
+        return document.querySelector('tbody>tr>td>pre').innerHTML;
+    }
+
+    async waitForSubmission(id: string, next, end) {
+        let count = 0;
+        while (count < 60) {
+            count++;
+            await sleep(3000);
+            const { text } = await this.get(`/status.php?first=${id}`);
+            const { window: { document } } = new JSDOM(text);
+            const recordNode = document.querySelector('#fixed_table>table>tbody>tr:nth-child(3)');
+            const statusText = recordNode.querySelector('td:nth-child(3) font').innerHTML;
+            const status = statusDict[statusText] || STATUS.STATUS_SYSTEM_ERROR;
+            if (status === STATUS.STATUS_JUDGING) continue;
+            const time = recordNode.querySelector('td:nth-child(5)').innerHTML;
+            const memory = recordNode.querySelector('td:nth-child(6)').innerHTML;
+            let message = {
+                status,
+                score: status === STATUS.STATUS_ACCEPTED ? 100 : 0,
+                time: parseTimeMS(time),
+                memory: parseMemoryMB(memory) * 1024,
+            };
+            if (status === STATUS.STATUS_COMPILE_ERROR)
+                message.compilerText = await this.getCompilerText(id);
+            await end(message);
+            return;
+        }
+    }
+}

--- a/packages/vjudge/src/providers/index.ts
+++ b/packages/vjudge/src/providers/index.ts
@@ -8,6 +8,7 @@ import luogu from './luogu';
 import poj from './poj';
 import spoj from './spoj';
 import uoj from './uoj';
+import hduoj from './hduoj';
 
 const vjudge: Record<string, any> = {
     codeforces,
@@ -21,5 +22,6 @@ const vjudge: Record<string, any> = {
     xjoi,
     ybt,
     ybtbas,
+    hduoj,
 };
 export default vjudge;

--- a/packages/vjudge/src/providers/index.ts
+++ b/packages/vjudge/src/providers/index.ts
@@ -1,5 +1,6 @@
 import codeforces from './codeforces';
 import csgoj from './csgoj';
+import hduoj from './hduoj';
 import {
     BZOJ as bzoj, HUSTOJ as hustoj, XJOI as xjoi, YBT as ybt,
     YBTBAS as ybtbas,
@@ -8,20 +9,19 @@ import luogu from './luogu';
 import poj from './poj';
 import spoj from './spoj';
 import uoj from './uoj';
-import hduoj from './hduoj';
 
 const vjudge: Record<string, any> = {
+    bzoj,
     codeforces,
     csgoj,
+    hduoj,
+    hustoj,
     'luogu.legacy': luogu,
     poj,
     spoj,
     uoj,
-    hustoj,
-    bzoj,
     xjoi,
     ybt,
     ybtbas,
-    hduoj,
 };
 export default vjudge;


### PR DESCRIPTION
添加 HDUOJ 远端评测。

### TODO

- [x] 题目列表抓取
- [ ] 题面抓取 & 处理
- [ ] 题面图片处理
- [ ] 题面抓取测试
- [x] 语言配置
- [x] 提交 & 评测

### 文档更新

域创建：`hydrooj cli domain add hduoj 1 HDUOJ HDUOJ`

域标记：`db.domain.updateOne({_id: 'hduoj'}, {$set: {mount: 'hduoj'}})`

添加账号：`db.vjudge.insert({type:'hduoj', handle:'<username>', password:'<password>'})`

系统设置 -> 语言：

```yaml
hduoj:
  display: G++
  execute: /bin/echo Invalid
  domain:
  - hduoj
hduoj.0:
  display: G++
  monaco: cpp
  highlight: cpp astyle-c
  comment: //
hduoj.1:
  display: GCC
  monaco: c
  highlight: c astyle-c
  comment: //
hduoj.2:
  display: C++
  monaco: cpp
  highlight: cpp astyle-c
  comment: //
hduoj.3:
  display: C
  monaco: c
  highlight: c astyle-c
  comment: //
hduoj.4:
  display: Pascal
  monaco: pascal
  highlight: pascal
  comment: //
hduoj.5:
  display: Java
  monaco: java
  highlight: java astyle-java
  comment: //
hduoj.6:
  display: C#
  monaco: csharp
  highlight: cpp astyle-cs
  comment: //
```

管理域 -> 语言限制：`hduoj,hduoj.0,hduoj.1,hduoj.2,hduoj.3,hduoj.4,hduoj.5,hduoj.6`