### PR TITLE
cli: allow parsing integer/string array

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -27,3 +27,5 @@ This Contribution License Agreement (**“Agreement”**) is agreed to by the pa
 8. **Information about Submissions**. You agree that contributions to Projects and information about contributions may be maintained indefinitely and disclosed publicly, including Your name and other information that You submit with Your Submission.
 
 9. **Entire Agreement/Assignment**. This Agreement is the entire agreement between the parties, and supersedes any and all prior agreements, understandings or communications, written or oral, between the parties relating to the subject matter hereof. This Agreement may be assigned by hydro-dev.
+
+I have read the CLA Document and I hereby sign the CLA

--- a/packages/hydrooj/src/entry/cli.ts
+++ b/packages/hydrooj/src/entry/cli.ts
@@ -74,6 +74,12 @@ async function cli() {
         } else if (args[i].startsWith('~')) {
             args[i] = argv.options[args[i].substr(1)];
         }
+        else if (args[i].startsWith('i[')) {
+            args[i] = args[i].substr(2, args[i].length - 3).split(',').map((x) => parseInt(x));
+        }
+        else if (args[i].startsWith('s[')) {
+            args[i] = args[i].substr(2, args[i].length - 3).split(',');
+        }
     }
     let result = global.Hydro.model[modelName][func](...args);
     if (result instanceof Promise) result = await result;


### PR DESCRIPTION
example usage: 
* hydrooj cli user updateGroup system group1 i[1,2,3] , comma-saperated, no space is allowed.
* i[1,2,3] will be parsed into [1,2,3]
* s[1,2,3] will be parsed into ['1','2','3']