### PR TITLE
judge: add limit to stack when strict_memory enabled

### DIFF
--- a/packages/hydrojudge/src/sandbox.ts
+++ b/packages/hydrojudge/src/sandbox.ts
@@ -101,7 +101,7 @@ function proc(params: Parameter): Cmd {
         clockLimit: 3 * cpuLimit,
         memoryLimit: Math.floor(memory * 1024 * 1024),
         strictMemoryLimit: getConfig('strict_memory'),
-        // stackLimit: memory * 1024 * 1024,
+        stackLimit: getConfig('strict_memory') ? Math.floor(memory * 1024 * 1024) : 0,
         procLimit: params.processLimit || getConfig('processLimit'),
         copyOutMax: Math.floor(1024 * 1024 * stdioLimit * 3),
         copyIn,


### PR DESCRIPTION
CCF limits the stack size same as the memory limit and `strict_memory` option is being primarily used to mimic CCF behavior so add this limit for that special usage.