### PR TITLE
Fix error when installing dependencies using yarn

### DIFF
--- a/packages/ui-default/package.json
+++ b/packages/ui-default/package.json
@@ -14,7 +14,7 @@
     "cli": false
   },
   "devDependencies": {
-    "@blueprintjs/core": "^5.6.0",
+    "@blueprintjs/core": "5.6.0",
     "@fontsource/dm-mono": "^5.0.17",
     "@fontsource/fira-code": "^5.0.15",
     "@fontsource/inconsolata": "^5.0.15",


### PR DESCRIPTION
Upgrade of `@blueprintjs/core` from 5.6.0 to 5.7.0 yields errors when using yarn.

see palantir/blueprint#6556