### PR TITLE
core: fix error when problem title is not actually string

### DIFF
--- a/packages/hydrooj/src/model/problem.ts
+++ b/packages/hydrooj/src/model/problem.ts
@@ -475,7 +475,7 @@ export class ProblemModel {
                 const content = fs.readFileSync(path.join(tmpdir, i, 'problem.yaml'), 'utf-8');
                 const pdoc: ProblemDoc = yaml.load(content) as any;
                 if (!pdoc) continue;
-                let pid: string | undefined = pdoc.pid;
+                let pid = pdoc.pid;
 
                 const isValidPid = async (id: string) => {
                     if (!(/^[A-Za-z]+[0-9A-Za-z]*$/.test(id))) return false;
@@ -492,9 +492,9 @@ export class ProblemModel {
                 }
                 const overrideContent = findOverrideContent(path.join(tmpdir, i));
                 if (pdoc.difficulty && !Number.isSafeInteger(pdoc.difficulty)) delete pdoc.difficulty;
-                const title = typeof pdoc.title === 'string' ? pdoc.title.trim() : (pdoc.title as any).toString().trim();
+                if (typeof pdoc.title !== 'string') throw new ValidationError('title', null, 'Invalid title');
                 const docId = await ProblemModel.add(
-                    domainId, pid, title, overrideContent || pdoc.content || 'No content',
+                    domainId, pid, pdoc.title.trim(), overrideContent || pdoc.content || 'No content',
                     operator || pdoc.owner, pdoc.tag || [], { hidden: pdoc.hidden, difficulty: pdoc.difficulty },
                 );
                 if (files.includes('testdata')) {


### PR DESCRIPTION
When title in `config.yaml` is not typed string, it crashed.
Also, add log to show which problem is importing, making it easier to find error.

![image](https://github.com/hydro-dev/Hydro/assets/69113276/d57cf0db-e961-4813-ad50-88ba9c59d750)
