### PR TITLE
core: websocket: use ping frame rather than ping message

### DIFF
--- a/packages/hydrooj/src/service/server.ts
+++ b/packages/hydrooj/src/service/server.ts
@@ -437,8 +437,11 @@ export function Connection(
                     clean();
                     conn.terminate();
                 }
-                if (Date.now() - lastHeartbeat > 30000) conn.send('ping');
+                if (Date.now() - lastHeartbeat > 30000) conn.ping();
             }, 40000);
+            conn.on('pong', () => {
+                lastHeartbeat = Date.now();
+            });
             conn.onmessage = (e) => {
                 lastHeartbeat = Date.now();
                 if (e.data === 'pong') return;


### PR DESCRIPTION
Use `ping` control frame rather than `ping` message to save 4 bytes for keep alive.