### PR TITLE
core: judge: optimize task assign

### DIFF
--- a/packages/hydrojudge/src/hosts/hydro.ts
+++ b/packages/hydrojudge/src/hosts/hydro.ts
@@ -224,6 +224,7 @@ export default class Hydro implements Session {
                         this.ws.send(JSON.stringify({ key: 'status', info: { mid, ...inf } }));
                     }, 1200000);
                 }
+                this.ws.send(content);
                 resolve(null);
             });
         });

--- a/packages/hydrooj/src/service/server.ts
+++ b/packages/hydrooj/src/service/server.ts
@@ -417,6 +417,7 @@ export function Connection(
                 h.compression = new Shorty();
                 conn.send('shorty');
             }
+            conn.pause();
             if (h._prepare) await h._prepare(args);
             if (h.prepare) await h.prepare(args);
             // eslint-disable-next-line @typescript-eslint/no-shadow
@@ -449,6 +450,7 @@ export function Connection(
                 h.message?.(JSON.parse(e.data.toString()));
             };
             conn.onclose = clean;
+            conn.resume();
             await bus.parallel('connection/active', h);
         } catch (e) {
             await h.onerror(e);


### PR DESCRIPTION
- fix performance degrade caused by the wait and check loop of 500ms (for example, it used to take 50s to judge 100 task even if the task finished immediately)
- use semaphore to limit concurrency
- send the concurrency config immediate after initialization (it used to take 30s before configured with desired concurrency)
- install WebSocket `onmessage` handler before async prepare to avoid ignorance of message