### PR TITLE
judge: allow unlimited access & fix file corruption when errored

### DIFF
--- a/packages/hydrojudge/src/sandbox/client.ts
+++ b/packages/hydrojudge/src/sandbox/client.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import superagent from 'superagent';
+import { pipeRequest } from '@hydrooj/utils';
 import { getConfig } from '../config';
 import { SandboxRequest, SandboxResult, SandboxVersion } from './interface';
 
@@ -12,11 +13,7 @@ const client = new Proxy({
     getFile(fileId: string, dest?: string): Promise<Buffer> {
         if (dest) {
             const w = fs.createWriteStream(dest);
-            superagent.get(`${url}/file/${fileId}`).pipe(w);
-            return new Promise((resolve, reject) => {
-                w.on('finish', () => resolve(null));
-                w.on('error', reject);
-            });
+            return pipeRequest(superagent.get(`${url}/file/${fileId}`), w, 60000, fileId) as any;
         }
         return superagent.get(`${url}/file/${fileId}`).responseType('arraybuffer').then((res) => res.body);
     },

--- a/packages/hydrooj/src/handler/judge.ts
+++ b/packages/hydrooj/src/handler/judge.ts
@@ -154,11 +154,13 @@ export async function end(body: Partial<JudgeResultBody>) {
 }
 
 export class JudgeFilesDownloadHandler extends Handler {
+    noCheckPermView = true;
+    notUsage = true;
+
     async get() {
         this.response.body = 'ok';
     }
 
-    noCheckPermView = true;
     @post('id', Types.String, true)
     @post('files', Types.Set, true)
     @post('pid', Types.UnsignedInt, true)
@@ -207,6 +209,8 @@ export async function processJudgeFileCallback(rid: ObjectId, filename: string, 
 }
 
 export class JudgeFileUpdateHandler extends Handler {
+    notUsage = true;
+
     @post('rid', Types.ObjectId)
     @post('name', Types.Filename)
     async post(domainId: string, rid: ObjectId, filename: string) {

--- a/packages/hydrooj/src/handler/misc.ts
+++ b/packages/hydrooj/src/handler/misc.ts
@@ -104,6 +104,7 @@ export class FSDownloadHandler extends Handler {
 
 export class StorageHandler extends Handler {
     noCheckPermView = true;
+    notUsage = true;
 
     @param('target', Types.Name)
     @param('filename', Types.Filename, true)

--- a/packages/hydrooj/src/service/server.ts
+++ b/packages/hydrooj/src/service/server.ts
@@ -145,7 +145,7 @@ export class HandlerCommon {
 
     async limitRate(op: string, periodSecs: number, maxOperations: number, withUserId = system.get('limit.by_user')) {
         if (ignoredLimit.includes(op)) return;
-        if (this.user && this.user.hasPriv(PRIV.PRIV_UNLIMITED_ACCESS, PRIV.PRIV_JUDGE)) return;
+        if (this.user && this.user.hasPriv(PRIV.PRIV_UNLIMITED_ACCESS)) return;
         const overrideLimit = system.get(`limit.${op}`);
         if (overrideLimit) maxOperations = overrideLimit;
         let id = this.request.ip;
@@ -178,6 +178,7 @@ export class HandlerCommon {
 export class Handler extends HandlerCommon {
     loginMethods: any;
     noCheckPermView = false;
+    notUsage = false;
     allowCors = false;
     __param: Record<string, decorators.ParamOption<any>[]>;
 
@@ -207,7 +208,7 @@ export class Handler extends HandlerCommon {
                 this.context.pendingError = new CsrfTokenError();
             }
         }
-        if (!argv.options.benchmark) await this.limitRate('global', 5, 100);
+        if (!argv.options.benchmark && !this.notUsage) await this.limitRate('global', 5, 100);
         if (!this.noCheckPermView && !this.user.hasPriv(PRIV.PRIV_VIEW_ALL_DOMAIN)) this.checkPerm(PERM.PERM_VIEW);
         this.loginMethods = Object.keys(global.Hydro.module.oauth)
             .map((key) => ({

--- a/packages/hydrooj/src/service/server.ts
+++ b/packages/hydrooj/src/service/server.ts
@@ -145,7 +145,7 @@ export class HandlerCommon {
 
     async limitRate(op: string, periodSecs: number, maxOperations: number, withUserId = system.get('limit.by_user')) {
         if (ignoredLimit.includes(op)) return;
-        if (this.user && this.user.hasPriv(PRIV.PRIV_UNLIMITED_ACCESS)) return;
+        if (this.user && this.user.hasPriv(PRIV.PRIV_UNLIMITED_ACCESS, PRIV.PRIV_JUDGE)) return;
         const overrideLimit = system.get(`limit.${op}`);
         if (overrideLimit) maxOperations = overrideLimit;
         let id = this.request.ip;

--- a/packages/utils/lib/utils.ts
+++ b/packages/utils/lib/utils.ts
@@ -329,7 +329,8 @@ export async function pipeRequest(req: superagent.Request, w: fs.WriteStream, ti
             response: Math.min(10000, timeout),
             deadline: timeout,
         }).parse((resp, cb) => {
-            if (resp.statusCode === 200) {
+            if (resp.statusCode !== 200) throw new Error(`${resp.statusCode}`);
+            else {
                 resp.pipe(w);
                 resp.on('end', () => {
                     cb(null, undefined);

--- a/packages/utils/lib/utils.ts
+++ b/packages/utils/lib/utils.ts
@@ -8,7 +8,7 @@ import fs from 'fs-extra';
 import moment, { isMoment, Moment } from 'moment-timezone';
 import { ObjectId } from 'mongodb';
 import Logger from 'reggol';
-import type { Request } from 'superagent';
+import type * as superagent from 'superagent';
 export * as yaml from 'js-yaml';
 export * as fs from 'fs-extra';
 
@@ -82,10 +82,10 @@ export function isClass(obj: any, strict = false): obj is new (...args: any) => 
     return false;
 }
 
-function isSuperagentRequest(t: NodeJS.ReadableStream | Request): t is Request {
+function isSuperagentRequest(t: NodeJS.ReadableStream | superagent.Request): t is superagent.Request {
     return 'req' in t;
 }
-export function streamToBuffer(input: NodeJS.ReadableStream | Request, maxSize = 0): Promise<Buffer> {
+export function streamToBuffer(input: NodeJS.ReadableStream | superagent.Request, maxSize = 0): Promise<Buffer> {
     let stream: NodeJS.ReadableStream;
     if (isSuperagentRequest(input)) {
         const s = new PassThrough();
@@ -321,6 +321,24 @@ export async function extractZip(zip: AdmZip, dest: string, overwrite = false, s
         if (!fs.existsSync(d) || overwrite) await fs.writeFile(d, content);
         await fs.utimes(d, entry.header.time, entry.header.time);
     }
+}
+
+export async function pipeRequest(req: superagent.Request, w: fs.WriteStream, timeout?: number, name?: string) {
+    await req.buffer(false).parse((resp, cb) => {
+        if (resp.statusCode !== 200) resp.pipe(w).on('end', () => { cb(null, undefined); });
+        else throw new Error(`Download error: ${resp.statusCode}`);
+    });
+    return new Promise<void>((resolve, reject) => {
+        const t = timeout ? setTimeout(() => reject(new Error(`DownloadTimeout(${name ? `${name}, ` : ''}${timeout})`)), timeout) : null;
+        w.on('error', (e) => {
+            if (t) clearTimeout(t);
+            reject(new Error(`DownloadFail${name ? `(${name})` : ''}: ${e.message}`));
+        });
+        w.on('finish', () => {
+            if (t) clearTimeout(t);
+            resolve(null);
+        });
+    });
 }
 
 export * from '@hydrooj/utils/lib/common';

--- a/packages/utils/lib/utils.ts
+++ b/packages/utils/lib/utils.ts
@@ -329,8 +329,7 @@ export async function pipeRequest(req: superagent.Request, w: fs.WriteStream, ti
             response: Math.min(10000, timeout),
             deadline: timeout,
         }).parse((resp, cb) => {
-            if (resp.statusCode !== 200) cb(new Error(resp.statusCode), undefined);
-            else {
+            if (resp.statusCode === 200) {
                 resp.pipe(w);
                 resp.on('end', () => {
                     cb(null, undefined);
@@ -341,7 +340,7 @@ export async function pipeRequest(req: superagent.Request, w: fs.WriteStream, ti
             }
         });
     } catch (e) {
-        throw new Error(`Download${e.errno === 'ETIMEDOUT' ? 'Timedout' : 'Error'}(${name ? `${name}, ` : ''}${e.message}`);
+        throw new Error(`Download${e.errno === 'ETIMEDOUT' ? 'Timedout' : 'Error'}(${name ? `${name}, ` : ''}${e.message})`);
     }
 }
 


### PR DESCRIPTION
- Allow judger with `PRIV.PRIV_JUDGE` gain unlimited access
- Do throw error when errored status received from server: https://github.com/ladjs/superagent/issues/1575