### PR TITLE
fix: judge/vj4 读取复制的数据会发生重定向错误

### DIFF
--- a/packages/hydrojudge/src/hosts/vj4.ts
+++ b/packages/hydrojudge/src/hosts/vj4.ts
@@ -131,7 +131,15 @@ export default class VJ4 implements Session {
         if (res.status === 404) throw new FormatError(`没有找到测试数据 ${domainId}/${pid}`);
         if (res.status === 302) {
             location = res.headers.location;
-            if (!location.includes('/fs/')) throw new Error();
+            if (!location.includes('/fs/')) {
+                const _res = await this.get(location).redirects(0).ok((r) => r.status === 302 || r.status === 404);
+                if (_res.status === 404) throw new FormatError(`没有找到测试数据 ${domainId}/${pid}`);
+                if (_res.status === 302) {
+                    location = _res.headers.location;
+                    if (!location.includes('/fs/')) throw new Error();
+                }
+                return _res.headers.location;
+            }
         }
         return res.headers.location;
     }


### PR DESCRIPTION
由于最多发生两次重定向，因此在一次 302 后，再次发起请求，再次 302 后再抛出错误。