### PR TITLE
core: async hash calculation

### DIFF
--- a/packages/hydrooj/src/handler/home.ts
+++ b/packages/hydrooj/src/handler/home.ts
@@ -216,8 +216,8 @@ class HomeSecurityHandler extends Handler {
         if (this.session.sudoUid) {
             const udoc = await user.getById(domainId, this.session.sudoUid);
             if (!udoc) throw new UserNotFoundError(this.session.sudoUid);
-            udoc.checkPassword(current);
-        } else this.user.checkPassword(current);
+            await udoc.checkPassword(current);
+        } else await this.user.checkPassword(current);
         await user.setPassword(this.user._id, password);
         await token.delByUid(this.user._id);
         this.response.redirect = this.url('user_login');
@@ -232,8 +232,8 @@ class HomeSecurityHandler extends Handler {
         if (this.session.sudoUid) {
             const udoc = await user.getById(domainId, this.session.sudoUid);
             if (!udoc) throw new UserNotFoundError(this.session.sudoUid);
-            udoc.checkPassword(current);
-        } else this.user.checkPassword(current);
+            await udoc.checkPassword(current);
+        } else await this.user.checkPassword(current);
         const udoc = await user.getByEmail(domainId, email);
         if (udoc) throw new UserAlreadyExistError(email);
         await this.limitRate('send_mail', 3600, 30);

--- a/packages/hydrooj/src/handler/user.ts
+++ b/packages/hydrooj/src/handler/user.ts
@@ -117,7 +117,7 @@ class UserLoginHandler extends Handler {
                 await token.del(authnChallenge, token.TYPE_WEBAUTHN);
             } else throw new ValidationError('2FA', 'Authn');
         }
-        udoc.checkPassword(password);
+        await udoc.checkPassword(password);
         await user.setById(udoc._id, { loginat: new Date(), loginip: this.request.ip });
         if (!udoc.hasPriv(PRIV.PRIV_USER_PROFILE)) throw new BlacklistedError(uname, udoc.banReason);
         this.session.viewLang = '';
@@ -153,7 +153,7 @@ class UserSudoHandler extends Handler {
             await token.del(authnChallenge, token.TYPE_WEBAUTHN);
         } else if (this.user.tfa && tfa) {
             if (!verifyTFA(this.user._tfa, tfa)) throw new InvalidTokenError('2FA');
-        } else this.user.checkPassword(password);
+        } else await this.user.checkPassword(password);
         this.session.sudo = Date.now();
         if (this.session.sudoArgs.method.toLowerCase() !== 'get') {
             this.response.template = 'user_sudo_redirect.html';
@@ -445,7 +445,7 @@ class UserDetailHandler extends Handler {
 
 class UserDeleteHandler extends Handler {
     async post({ password }) {
-        this.user.checkPassword(password);
+        await this.user.checkPassword(password);
         const tid = await ScheduleModel.add({
             executeAfter: moment().add(7, 'days').toDate(),
             type: 'script',

--- a/packages/hydrooj/src/interface.ts
+++ b/packages/hydrooj/src/interface.ts
@@ -787,7 +787,7 @@ export interface ModuleInterfaces {
         get: (this: Handler) => Promise<void>;
         callback: (this: Handler, args: Record<string, any>) => Promise<OAuthUserResponse>;
     };
-    hash: (password: string, salt: string, user: User) => boolean | string;
+    hash: (password: string, salt: string, user: User) => boolean | string | Promise<string>;
     render: (name: string, state: any) => string | Promise<string>;
 }
 

--- a/packages/hydrooj/src/lib/hash.hydro.ts
+++ b/packages/hydrooj/src/lib/hash.hydro.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 
-async function hash(password: string, salt: string): Promise<string> {
+function hash(password: string, salt: string): Promise<string> {
     return new Promise((resolve, reject) => {
         crypto.pbkdf2(password, salt, 100000, 64, 'sha256', (err, key) => {
             if (err) reject(err);

--- a/packages/hydrooj/src/lib/hash.hydro.ts
+++ b/packages/hydrooj/src/lib/hash.hydro.ts
@@ -1,7 +1,12 @@
 import crypto from 'crypto';
 
-function hash(password: string, salt: string) {
-    return crypto.pbkdf2Sync(password, salt, 100000, 64, 'sha256').toString('hex').substring(0, 64);
+async function hash(password: string, salt: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        crypto.pbkdf2(password, salt, 100000, 64, 'sha256', (err, key) => {
+            if (err) reject(err);
+            else resolve(key.toString('hex').substring(0, 64));
+        });
+    });
 }
 
 export = hash;

--- a/packages/hydrooj/src/model/user.ts
+++ b/packages/hydrooj/src/model/user.ts
@@ -144,10 +144,7 @@ export class User {
     async checkPassword(password: string) {
         const h = global.Hydro.module.hash[this.hashType];
         if (!h) throw new Error('Unknown hash method');
-        let result = h(password, this._salt, this);
-        if (result instanceof Promise) {
-            result = await result;
-        }
+        const result = await h(password, this._salt, this);
         if (result !== true && result !== this._hash) {
             throw new LoginError(this.uname);
         }


### PR DESCRIPTION
The `pbkdf2` function is a CPU consuming operation (~50ms on m1) so using `sync` version blocks the Nodejs event loop for a while during request. Changing it into async version allows it to be calculated in worker thread without blocking. Stress test shows ~75% latency reduction.

before:
```
$ wrk -c8 -t1 -d5s -s login.lua http://localhost:2333/login
Running 5s test @ http://localhost:2333/login
  1 threads and 8 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   398.81ms  113.01ms 711.82ms   72.45%
    Req/Sec    19.38      6.48    34.00     79.17%
  98 requests in 5.01s, 40.96KB read
Requests/sec:     19.55
Transfer/sec:      8.17KB
```

after:
```
$ wrk -c8 -t1 -d5s -s login.lua http://localhost:2333/login
Running 5s test @ http://localhost:2333/login
  1 threads and 8 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   101.32ms    4.36ms 141.85ms   94.43%
    Req/Sec    78.42      7.85    90.00     74.00%
  395 requests in 5.05s, 165.10KB read
Requests/sec:     78.24
Transfer/sec:     32.70KB

```