### PR TITLE
ui: fix discuss history view height

### DIFF
--- a/packages/ui-default/components/discussion/history.page.tsx
+++ b/packages/ui-default/components/discussion/history.page.tsx
@@ -14,7 +14,9 @@ async function historyDialog(payload, time, uid) {
     $body: tpl`
       <div class="typo richmedia">
         <p><div data-user>${uid}</div> ${i18n('Edited at')} <span class="time relative" data-timestamp="${ts / 1000}">${time}</span></p>
-        ${{ templateRaw: true, html: rawHtml }}
+        <div style="scroll-behavior: smooth; max-height: 60vh; overflow: auto;">
+          ${{ templateRaw: true, html: rawHtml }}
+        </div>
       </div>`,
   }).open();
 }


### PR DESCRIPTION
before:

<img width="750" alt="Snipaste_2024-05-02_21-37-14" src="https://github.com/hydro-dev/Hydro/assets/69113276/aa7b1774-869c-4ef9-b629-901eedc1fe63">

after:

<img width="795" alt="Snipaste_2024-05-02_21-39-28" src="https://github.com/hydro-dev/Hydro/assets/69113276/81ba3a8c-334c-4058-a4bc-71e64c11568f">
