### PR TITLE
judge: distinguish sandbox error between old version and not running

### DIFF
--- a/packages/hydrojudge/src/sandbox.ts
+++ b/packages/hydrojudge/src/sandbox.ts
@@ -226,11 +226,12 @@ export async function versionCheck(reportWarn: (str: string) => void, reportErro
     let sandboxCgroup: number;
     try {
         const version = await client.version();
+        if (!version.copyOutOptional) reportError('Your sandbox version is tooooooo low! Please upgrade!');
         sandboxVersion = version.buildVersion.split('v')[1];
         const config = await client.config();
         sandboxCgroup = config.runnerConfig?.cgroupType || 0;
     } catch (e) {
-        reportError('Your sandbox version is tooooooo low! Please upgrade!');
+        reportError('Your sandbox is not running. Please check status via `pm2 ls` or log via `pm2 log hydro-sandbox`.');
         return false;
     }
     const { osinfo } = await sysinfo.get();

--- a/packages/hydrojudge/src/sandbox.ts
+++ b/packages/hydrojudge/src/sandbox.ts
@@ -230,7 +230,7 @@ export async function versionCheck(reportWarn: (str: string) => void, reportErro
         const config = await client.config();
         sandboxCgroup = config.runnerConfig?.cgroupType || 0;
     } catch (e) {
-        if (e?.code === 'ECONNREFUSED') reportError('Your sandbox is not running. Please check status via `pm2 ls` or `pm2 log hydro-sandbox`.');
+        if (e?.code === 'ECONNREFUSED') reportError('Connecting to sandbox failed, please check sandbox_host config and if your sandbox is running.');
         else reportError('Your sandbox version is tooooooo low! Please upgrade!');
         return false;
     }

--- a/packages/hydrojudge/src/sandbox.ts
+++ b/packages/hydrojudge/src/sandbox.ts
@@ -226,12 +226,12 @@ export async function versionCheck(reportWarn: (str: string) => void, reportErro
     let sandboxCgroup: number;
     try {
         const version = await client.version();
-        if (!version.copyOutOptional) reportError('Your sandbox version is tooooooo low! Please upgrade!');
         sandboxVersion = version.buildVersion.split('v')[1];
         const config = await client.config();
         sandboxCgroup = config.runnerConfig?.cgroupType || 0;
     } catch (e) {
-        reportError('Your sandbox is not running. Please check status via `pm2 ls` or log via `pm2 log hydro-sandbox`.');
+        if (e?.code === 'ECONNREFUSED') reportError('Your sandbox is not running. Please check status via `pm2 ls` or `pm2 log hydro-sandbox`.');
+        else reportError('Your sandbox version is tooooooo low! Please upgrade!');
         return false;
     }
     const { osinfo } = await sysinfo.get();

--- a/packages/hydrojudge/src/sandbox.ts
+++ b/packages/hydrojudge/src/sandbox.ts
@@ -230,7 +230,7 @@ export async function versionCheck(reportWarn: (str: string) => void, reportErro
         const config = await client.config();
         sandboxCgroup = config.runnerConfig?.cgroupType || 0;
     } catch (e) {
-        if (e?.code === 'ECONNREFUSED') reportError('Connecting to sandbox failed, please check sandbox_host config and if your sandbox is running.');
+        if (e?.syscall === 'connect') reportError('Connecting to sandbox failed, please check sandbox_host config and if your sandbox is running.');
         else reportError('Your sandbox version is tooooooo low! Please upgrade!');
         return false;
     }


### PR DESCRIPTION
- If sandbox is failing, the current error message is misleading
- Added check and instruction to debug in the information when connection failing