### PR TITLE
fix(ui): prevent content from overflowing the display area

### DIFF
--- a/packages/ui-default/misc/typography.styl
+++ b/packages/ui-default/misc/typography.styl
@@ -261,6 +261,7 @@ small, figcaption
 
 .typo
   word-wrap()
+  overflow: auto
 
 .typo a, .typo .link, .typo-a
   &, &:visited, &:active, &:hover


### PR DESCRIPTION
## 修改前

![image](https://github.com/user-attachments/assets/731498dc-83a4-4a87-b5ac-00a6f8bc9018)

## 修改后

![image](https://github.com/user-attachments/assets/a018c416-f8b6-4617-a635-89b67bb4ae49)
