### PR TITLE
core: fix OI mode contest bug seeing the judging result when shouldn't

### DIFF
--- a/packages/hydrooj/src/handler/contest.ts
+++ b/packages/hydrooj/src/handler/contest.ts
@@ -222,7 +222,7 @@ export class ContestProblemListHandler extends ContestDetailBaseHandler {
             contest.getMultiClarification(domainId, tid, this.user._id),
         ]);
         this.response.body = {
-            pdict, psdict: {}, udict, rdict: {}, tdoc: this.tdoc, tsdoc: {}, tcdocs,
+            pdict, psdict: {}, udict, rdict: {}, tdoc: this.tdoc, tcdocs,
         };
         this.response.template = 'contest_problemlist.html';
         this.response.body.showScore = Object.values(this.tdoc.score || {}).some((i) => i && i !== 100);
@@ -231,18 +231,18 @@ export class ContestProblemListHandler extends ContestDetailBaseHandler {
             await contest.setStatus(domainId, tid, this.user._id, { startAt: new Date() });
             this.tsdoc.startAt = new Date();
         }
+        this.response.body.tsdoc = pick(this.tsdoc, ['attend', 'startAt', ...(this.tdoc.duration ? ['endAt'] : [])]);
         this.response.body.psdict = this.tsdoc.detail || {};
         const psdocs: any[] = Object.values(this.response.body.psdict);
         const canViewRecord = contest.canShowSelfRecord.call(this, this.tdoc);
         this.response.body.canViewRecord = canViewRecord;
-        [this.response.body.rdict, this.response.body.rdocs, this.response.body.tsdoc] = canViewRecord
+        [this.response.body.rdict, this.response.body.rdocs] = canViewRecord
             ? await Promise.all([
                 record.getList(domainId, psdocs.map((i: any) => i.rid)),
                 record.getMulti(domainId, { contest: tid, uid: this.user._id })
                     .sort({ _id: -1 }).toArray(),
-                this.tsdoc,
             ])
-            : [Object.fromEntries(psdocs.map((i) => [i.rid, { _id: i.rid }])), [], []];
+            : [Object.fromEntries(psdocs.map((i) => [i.rid, { _id: i.rid }])), []];
         if (!this.user.own(this.tdoc) && !this.user.hasPerm(PERM.PERM_EDIT_CONTEST)) {
             this.response.body.rdocs = this.response.body.rdocs.map((rdoc) => contest.applyProjection(this.tdoc, rdoc, this.user));
             for (const psdoc of psdocs) {

--- a/packages/hydrooj/src/handler/contest.ts
+++ b/packages/hydrooj/src/handler/contest.ts
@@ -222,7 +222,7 @@ export class ContestProblemListHandler extends ContestDetailBaseHandler {
             contest.getMultiClarification(domainId, tid, this.user._id),
         ]);
         this.response.body = {
-            pdict, psdict: {}, udict, rdict: {}, tdoc: this.tdoc, tsdoc: this.tsdoc, tcdocs,
+            pdict, psdict: {}, udict, rdict: {}, tdoc: this.tdoc, tsdoc: {}, tcdocs,
         };
         this.response.template = 'contest_problemlist.html';
         this.response.body.showScore = Object.values(this.tdoc.score || {}).some((i) => i && i !== 100);
@@ -235,13 +235,14 @@ export class ContestProblemListHandler extends ContestDetailBaseHandler {
         const psdocs: any[] = Object.values(this.response.body.psdict);
         const canViewRecord = contest.canShowSelfRecord.call(this, this.tdoc);
         this.response.body.canViewRecord = canViewRecord;
-        [this.response.body.rdict, this.response.body.rdocs] = canViewRecord
+        [this.response.body.rdict, this.response.body.rdocs, this.response.body.tsdoc] = canViewRecord
             ? await Promise.all([
                 record.getList(domainId, psdocs.map((i: any) => i.rid)),
                 record.getMulti(domainId, { contest: tid, uid: this.user._id })
                     .sort({ _id: -1 }).toArray(),
+                this.tsdoc,
             ])
-            : [Object.fromEntries(psdocs.map((i) => [i.rid, { _id: i.rid }])), []];
+            : [Object.fromEntries(psdocs.map((i) => [i.rid, { _id: i.rid }])), [], []];
         if (!this.user.own(this.tdoc) && !this.user.hasPerm(PERM.PERM_EDIT_CONTEST)) {
             this.response.body.rdocs = this.response.body.rdocs.map((rdoc) => contest.applyProjection(this.tdoc, rdoc, this.user));
             for (const psdoc of psdocs) {


### PR DESCRIPTION
Contest attendees should not see the submission results in OI contest mode, but the results are leaked in the raw data.

The `tsdoc` object, which includes the submission results, should not be returned to the client if `canViewRecord` is false. The issue could make the OI mode contest unfair and become an IOI contest.

-----

View in the webpage UI: 
![image](https://github.com/user-attachments/assets/55692d32-03e5-4fdc-8d15-27e9b7c224c4)

View in the raw JSON:
![image](https://github.com/user-attachments/assets/a9e30d6d-52c2-43af-bc69-ff07fa78fb4a)

A sample hacker (copied from an decompiled extend userscript):
```javascript
async function PredictScore() {
      if (BasicMain.pageName() !== "record_detail") return;
      await new Promise(resolve => BasicMain.on("record_detail.prepare", () => resolve()));
      if (!UiContext.tdoc || UiContext.tdoc.rule !== "oi" || UiContext.rdoc.status) return;
      let ContestID = UiContext.tdoc._id,
          ProblemID = UiContext.pdoc.docId;
      if (!UiContext.tdoc.pids.includes(ProblemID)) return;
      let ProblemList = await WebRequestClass.get(`/d/${BasicMain.getDomainId()}/contest/${ContestID}/problems`).query({ _: Date.now() }),
          Record = Object.fromEntries(ProblemList.body.tsdoc.journal.map(Problem => [Problem.rid, Problem]))[UiContext.rdoc._id];
      if (typeof Record?.score == "number") {
          $(".section.side > .section__body").append(`
              <dl class="large horizontal" id="summary">
                  <dt>预估分数 <a href="javascript:;" class="exhloj-expect-score"><span class="icon icon-help"></span></a></dt>
                  <dd>${Record.status === 0 ? "努力预测中" : Record.score}</dd>
              </div>
          `);
          $(document).on("click", ".exhloj-expect-score", () => new Hydro.components.InfoDialog({
              $body: "预估分数是 Extend HLOJ 插件的 @exhloj/contest-helper 模块提供的 AI 智能分数预测功能。"
          }).open())
      }
  }
```