### PR TITLE
core: force uname to be a string in setUname()

### DIFF
--- a/packages/hydrooj/src/model/user.ts
+++ b/packages/hydrooj/src/model/user.ts
@@ -277,7 +277,7 @@ class UserModel {
 
     @ArgMethod
     static setUname(uid: number, uname: string) {
-        return UserModel.setById(uid, { uname, unameLower: uname.trim().toLowerCase() });
+        return UserModel.setById(uid, { uname: String(uname), unameLower: String(uname).trim().toLowerCase() });
     }
 
     @ArgMethod


### PR DESCRIPTION
当在命令行中调用 `hydrooj cli user setUname` 时，如果第二个参数（新用户名）为数字时，传递到函数中会变为 `number` 类型，导致在 `uname.trim()` 处报错。