### PR TITLE
judge: add communication problem support (#834)

### DIFF
--- a/packages/hydrojudge/src/cases.ts
+++ b/packages/hydrojudge/src/cases.ts
@@ -20,6 +20,9 @@ function isValidConfig(config) {
         throw new FormatError('Total time limit longer than {0}s. Cancelled.', [+getConfig('total_time_limit') || 60]);
     }
     const memMax = Math.max(...config.subtasks.flatMap((subtask) => subtask.cases.map((c) => c.memory)));
+    if (config.type === 'communication' && (config.num_processes || 2) > getConfig('processLimit')) {
+        throw new FormatError('Number of processes larger than processLimit');
+    }
     if (memMax > parseMemoryMB(getConfig('memoryMax'))) throw new FormatError('Memory limit larger than memory_max');
     if (!['default', 'strict'].includes(config.checker_type || 'default') && !config.checker) {
         throw new FormatError('You did not specify a checker.');

--- a/packages/hydrojudge/src/cases.ts
+++ b/packages/hydrojudge/src/cases.ts
@@ -15,7 +15,7 @@ function isValidConfig(config) {
     if (config.type !== 'objective' && config.count > (getConfig('testcases_max') || 100)) {
         throw new FormatError('Too many testcases. Cancelled.');
     }
-    const time = Math.sum(...config.subtasks.flatMap((subtask) => subtask.cases.map((c) => c.time)));
+    const time = (config.num_processes || 1) * Math.sum(...config.subtasks.flatMap((subtask) => subtask.cases.map((c) => c.time)));
     if (time > (getConfig('total_time_limit') || 60) * 1000) {
         throw new FormatError('Total time limit longer than {0}s. Cancelled.', [+getConfig('total_time_limit') || 60]);
     }

--- a/packages/hydrojudge/src/compile.ts
+++ b/packages/hydrojudge/src/compile.ts
@@ -51,7 +51,7 @@ const testlibFile = {
 };
 
 export async function compileLocalFile(
-    src: string, type: 'checker' | 'validator' | 'interactor' | 'generator' | 'std',
+    src: string, type: 'checker' | 'validator' | 'interactor' | 'generator' | 'manager' | 'std',
     getLang, copyIn: CopyIn, withTestlib = true, next?: any,
 ) {
     const s = src.replace('@', '.').split('.');

--- a/packages/hydrojudge/src/judge/communication.ts
+++ b/packages/hydrojudge/src/judge/communication.ts
@@ -29,17 +29,18 @@ function judgeCase(c: NormalizedCase) {
                 processLimit: process_limit,
             });
             pipeMapping.push({
+                name: `sol2mgr[${i}]`,
                 in: { index: i + 1, fd: 1 },
                 out: { index: 0, fd: i * 2 + 3 },
             });
             pipeMapping.push({
+                name: `mgr2sol[${i}]`,
                 in: { index: 0, fd: i * 2 + 4 },
                 out: { index: i + 1, fd: 0 },
             });
         }
         execute[0].execute += managerArgs;
         const res = await runPiped(execute, pipeMapping);
-        console.info(res);
         const resManager = res[0];
         let time = 0;
         let memory = 0;
@@ -62,10 +63,10 @@ function judgeCase(c: NormalizedCase) {
             }
         }
         if (status === STATUS.STATUS_ACCEPTED) {
-            console.info(resManager.stdout, resManager.stderr);
-            score = 100;
-            // { status, score, message } = parseManagerMessage(resManager.stderr, c.score);
-            if (resManager.code && !(resManager.stderr || '').trim().length) message += ` (Manager exited with code ${resManager.code})`;
+            score = Math.floor(c.score * (+resManager.stdout || 0));
+            status = score === c.score ? STATUS.STATUS_ACCEPTED : STATUS.STATUS_WRONG_ANSWER;
+            message = resManager.stderr;
+            if (resManager.code) message += ` (Manager exited with code ${resManager.code})`;
         }
         return {
             id: c.id,

--- a/packages/hydrojudge/src/judge/communication.ts
+++ b/packages/hydrojudge/src/judge/communication.ts
@@ -11,11 +11,8 @@ function judgeCase(c: NormalizedCase) {
         let managerArgs = '';
         const execute: Parameter[] = [{
             execute: ctx.executeManager.execute,
-            copyIn: {
-                in: c.input ? { src: c.input } : { content: '' },
-                out: c.output ? { src: c.output } : { content: '' },
-                ...ctx.executeManager.copyIn,
-            },
+            stdin: c.input ? { src: c.input } : { content: '' },
+            copyIn: ctx.executeManager.copyIn,
             time: c.time * 2,
             memory: c.memory * 2,
             env: { ...ctx.env, HYDRO_TESTCASE: c.id.toString() },
@@ -42,6 +39,7 @@ function judgeCase(c: NormalizedCase) {
         }
         execute[0].execute += managerArgs;
         const res = await runPiped(execute, pipeMapping);
+        console.info(res);
         const resManager = res[0];
         let time = 0;
         let memory = 0;

--- a/packages/hydrojudge/src/judge/index.ts
+++ b/packages/hydrojudge/src/judge/index.ts
@@ -1,3 +1,4 @@
+import * as communication from './communication';
 import * as def from './default';
 import * as generate from './generate';
 import * as hack from './hack';
@@ -8,5 +9,5 @@ import * as run from './run';
 import * as submit_answer from './submit_answer';
 
 export = {
-    default: def, generate, interactive, run, submit_answer, objective, hack,
+    default: def, generate, interactive, communication, run, submit_answer, objective, hack,
 } as Record<string, { judge(ctx: Context): Promise<void> }>;

--- a/packages/hydrojudge/src/judge/interactive.ts
+++ b/packages/hydrojudge/src/judge/interactive.ts
@@ -33,8 +33,8 @@ function judgeCase(c: NormalizedCase) {
                 env: { ...ctx.env, HYDRO_TESTCASE: c.id.toString() },
             },
         ], [
-            { in: { index: 0, fd: 1 }, out: { index: 1, fd: 0 } },
-            { in: { index: 1, fd: 1 }, out: { index: 0, fd: 0 } },
+            { in: { index: 0, fd: 1 }, out: { index: 1, fd: 0 }, name: 'userToInteractor' },
+            { in: { index: 1, fd: 1 }, out: { index: 0, fd: 0 }, name: 'interactorToUser' },
         ]);
         // TODO handle tout (maybe pass to checker?)
         let status: number;

--- a/packages/hydrojudge/src/judge/interactive.ts
+++ b/packages/hydrojudge/src/judge/interactive.ts
@@ -32,7 +32,10 @@ function judgeCase(c: NormalizedCase) {
                 copyOut: ['/w/tout?'],
                 env: { ...ctx.env, HYDRO_TESTCASE: c.id.toString() },
             },
-        ], [[0, 1], [1, 0]]);
+        ], [
+            { in: { index: 0, fd: 1 }, out: { index: 1, fd: 0 } },
+            { in: { index: 1, fd: 1 }, out: { index: 0, fd: 0 } },
+        ]);
         // TODO handle tout (maybe pass to checker?)
         let status: number;
         let score = 0;

--- a/packages/hydrojudge/src/judge/interface.ts
+++ b/packages/hydrojudge/src/judge/interface.ts
@@ -20,6 +20,7 @@ export interface RuntimeContext {
     execute?: Execute;
     checker?: Execute;
     executeInteractor?: Execute;
+    executeManager?: Execute;
     executeUser?: Execute;
 
     _callbackAwait?: Promise<any>;

--- a/packages/hydrojudge/src/sandbox.ts
+++ b/packages/hydrojudge/src/sandbox.ts
@@ -161,9 +161,9 @@ export async function runPiped(
                 ...pipe,
             })),
         };
-        for (const c of body.cmd) {
-            c.files[0] = null;
-            c.files[1] = null;
+        for (let i = 0; i < body.cmd.length; i++) {
+            if (pipeMapping.find((pipe) => pipe.out.index === i && pipe.out.fd === 0)) body.cmd[i].files[0] = null;
+            if (pipeMapping.find((pipe) => pipe.in.index === i && pipe.in.fd === 1)) body.cmd[i].files[1] = null;
         }
         const id = callId++;
         if (argv.options.showSandbox) logger.debug('%d %s', id, JSON.stringify(body));

--- a/packages/hydrojudge/src/sandbox.ts
+++ b/packages/hydrojudge/src/sandbox.ts
@@ -4,7 +4,6 @@ import { gte } from 'semver';
 import { ParseEntry } from 'shell-quote';
 import { STATUS } from '@hydrooj/utils/lib/status';
 import * as sysinfo from '@hydrooj/utils/lib/sysinfo';
-import { Optional } from 'hydrooj';
 import { getConfig } from './config';
 import { FormatError, SystemError } from './error';
 import { Logger } from './log';
@@ -147,7 +146,7 @@ async function adaptResult(result: SandboxResult, params: Parameter): Promise<Sa
 }
 
 export async function runPiped(
-    execute: Parameter[], pipeMapping: Optional<PipeMap, 'proxy' | 'name' | 'max'>[],
+    execute: Parameter[], pipeMapping: Pick<PipeMap, 'in' | 'out' | 'name'>[],
 ): Promise<SandboxAdaptedResult[]> {
     let res: SandboxResult[];
     const size = parseMemoryMB(getConfig('stdio_size'));
@@ -156,7 +155,6 @@ export async function runPiped(
             cmd: execute.map((exe) => proc(exe)),
             pipeMapping: pipeMapping.map((pipe) => ({
                 proxy: true,
-                name: 'stdout',
                 max: 1024 * 1024 * size,
                 ...pipe,
             })),

--- a/packages/hydrojudge/src/task.ts
+++ b/packages/hydrojudge/src/task.ts
@@ -135,7 +135,7 @@ export class JudgeTask {
         return result;
     }
 
-    async compileLocalFile(type: 'interactor' | 'validator' | 'checker' | 'generator' | 'std', file: string, checkerType?: string) {
+    async compileLocalFile(type: 'interactor' | 'validator' | 'checker' | 'generator' | 'manager' | 'std', file: string, checkerType?: string) {
         if (type === 'checker' && ['default', 'strict'].includes(checkerType)) return { execute: '', copyIn: {}, clean: () => Promise.resolve(null) };
         if (type === 'checker' && !checkers[checkerType]) throw new FormatError('Unknown checker type {0}.', [checkerType]);
         const withTestlib = type !== 'std' && (type !== 'checker' || checkerType === 'testlib');

--- a/packages/hydrooj/src/interface.ts
+++ b/packages/hydrooj/src/interface.ts
@@ -165,6 +165,7 @@ export enum ProblemType {
     Default = 'default',
     SubmitAnswer = 'submit_answer',
     Interactive = 'interactive',
+    Communication = 'communication',
     Objective = 'objective',
     Remote = 'remote_judge',
 }
@@ -196,6 +197,8 @@ export interface ProblemConfigFile {
     checker_type?: string;
     checker?: string;
     interactor?: string;
+    manager?: string;
+    num_processes?: number;
     user_extra_files?: string[];
     judge_extra_files?: string[];
     detail?: boolean;

--- a/packages/ui-default/components/monaco/schema/problemconfig.ts
+++ b/packages/ui-default/components/monaco/schema/problemconfig.ts
@@ -52,7 +52,7 @@ const problemConfigSchema: JSONSchema7 = {
   properties: {
     redirect: { type: 'string', pattern: '[0-9a-zA-Z_-]+\\/[0-9]+' },
     key: { type: 'string', pattern: '[0-9a-f]{32}' },
-    type: { enum: ['default', 'interactive', 'submit_answer', 'objective', 'remote_judge'] },
+    type: { enum: ['default', 'interactive', 'communication', 'submit_answer', 'objective', 'remote_judge'] },
     subType: { type: 'string' },
     langs: { type: 'array', items: { type: 'string' } },
     target: { type: 'string' },
@@ -64,6 +64,8 @@ const problemConfigSchema: JSONSchema7 = {
       ],
     },
     interactor: { type: 'string', pattern: '\\.' },
+    manager: { type: 'string', pattern: '\\.' },
+    num_processes: { type: 'number', minimum: 1, maximum: 5 },
     validator: { type: 'string', pattern: '\\.' },
     user_extra_files: { type: 'array', items: { type: 'string' } },
     judge_extra_files: { type: 'array', items: { type: 'string' } },

--- a/packages/ui-default/components/problemconfig/ProblemConfigEditor.tsx
+++ b/packages/ui-default/components/problemconfig/ProblemConfigEditor.tsx
@@ -29,9 +29,9 @@ interface Props {
 const configKey = [
   'type', 'subType', 'target', 'score', 'time',
   'memory', 'filename', 'checker_type', 'checker', 'interactor',
-  'validator', 'user_extra_files', 'judge_extra_files', 'detail', 'outputs',
-  'redirect', 'cases', 'subtasks', 'langs', 'key',
-  'time_limit_rate', 'memory_limit_rate',
+  'manager', 'num_processes', 'validator', 'user_extra_files', 'judge_extra_files',
+  'detail', 'outputs', 'redirect', 'cases', 'subtasks',
+  'langs', 'key', 'time_limit_rate', 'memory_limit_rate',
 ];
 
 const subtasksKey = [

--- a/packages/ui-default/components/problemconfig/ProblemType.tsx
+++ b/packages/ui-default/components/problemconfig/ProblemType.tsx
@@ -134,7 +134,7 @@ export default function ProblemType() {
             )}
           />
           <Tab
-            id="Communication"
+            id="communication"
             title={i18n('problem_type.communication')}
             panel={(
               <div className="row">

--- a/packages/ui-default/components/problemconfig/ProblemType.tsx
+++ b/packages/ui-default/components/problemconfig/ProblemType.tsx
@@ -134,6 +134,17 @@ export default function ProblemType() {
             )}
           />
           <Tab
+            id="Communication"
+            title={i18n('problem_type.communication')}
+            panel={(
+              <div className="row">
+                <FormItem columns={6} label="Manager">
+                  <SingleFileSelect formKey="manager" />
+                </FormItem>
+              </div>
+            )}
+          />
+          <Tab
             id="submit_answer"
             title={i18n('problem_type.submit_answer')}
             panel={(

--- a/packages/ui-default/components/problemconfig/ProblemType.tsx
+++ b/packages/ui-default/components/problemconfig/ProblemType.tsx
@@ -12,6 +12,7 @@ export default function ProblemType() {
   const Type = useSelector((state: RootState) => state.config.type);
   const checkerType = useSelector((state: RootState) => state.config.checker_type);
   const filename = useSelector((state: RootState) => state.config.filename);
+  const numProcesses = useSelector((state: RootState) => state.config.num_processes);
   const subType = useSelector((state: RootState) => state.config.subType);
   const checker = useSelector((state: RootState) => state.config.checker);
   const [category, setCategory] = React.useState('');
@@ -140,6 +141,14 @@ export default function ProblemType() {
               <div className="row">
                 <FormItem columns={6} label="Manager">
                   <SingleFileSelect formKey="manager" />
+                </FormItem>
+                <FormItem columns={6} label="Number of Processes">
+                  <input
+                    defaultValue={numProcesses || 2}
+                    placeholder="2"
+                    onChange={(ev) => dispatch(({ type: 'CONFIG_FORM_UPDATE', key: 'num_processes', value: +ev.currentTarget.value }))}
+                    className="textbox"
+                  />
                 </FormItem>
               </div>
             )}

--- a/packages/ui-default/locales/en.yaml
+++ b/packages/ui-default/locales/en.yaml
@@ -29,6 +29,7 @@ problem_solution: Problem Solution
 problem_submit: Problem Submit
 problem_type.default: 'Type: Default'
 problem_type.interactive: 'Type: Interactive'
+problem_type.communication: 'Type: Communication'
 problem_type.objective: 'Type: Objective'
 problem_type.remote_judge: 'Type: RemoteJudge'
 problem_type.submit_answer: 'Type: SubmitAnswer'

--- a/packages/ui-default/locales/zh.yaml
+++ b/packages/ui-default/locales/zh.yaml
@@ -700,6 +700,7 @@ problem_solution: 题解
 problem_submit: 递交代码
 problem_type.default: 传统题
 problem_type.interactive: 交互题
+problem_type.communication: 通信题
 problem_type.objective: 客观题
 problem_type.remote_judge: 远端评测题
 problem_type.submit_answer: 提交答案题

--- a/packages/utils/lib/cases.ts
+++ b/packages/utils/lib/cases.ts
@@ -19,6 +19,7 @@ export default async function readYamlCases(cfg: Record<string, any> = {}, check
             config.checker ||= checkFile(cfg.checker, 'Cannot find checker {0}.');
         }
         if (cfg.interactor) config.interactor = checkFile(cfg.interactor, 'Cannot find interactor {0}.');
+        if (cfg.manager) config.manager = checkFile(cfg.manager, 'Cannot find Manager {0}.');
         if (cfg.validator) config.validator = checkFile(cfg.validator, 'Cannot find validator {0}.');
         for (const n of ['judge', 'user']) {
             const conf = cfg[`${n}_extra_files`];


### PR DESCRIPTION
支持 [CMS](https://cms-dev.github.io/) 的通信题格式（使用 CMS 的知名赛事：IOI，CEOI，JOISC 等）。

相关文档：https://cms.readthedocs.io/en/v1.5/Task%20types.html#communication

配置文件中的 `manager` 表示用户进程的控制器，`num_processes` 表示参与通信的用户进程数目。一般而言需要提供自定义编译命令 `compile.sh`，也可以直接使用 IO 交互。

示例题目：[IOI 2024 Day 1, B. Message](https://hydro.ac/d/communication_example/p/1) （题目资料来源于[此处](https://www.ioi2024.eg/competition-tasks)）

其他的通信题就只有 UOJ 的通信题格式了，不过 UOJ 的自定义 `judger.cpp` 应该很难实现。