### PR TITLE
workspace: fix build:ui:production oom

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "build:ui:iconfont": "node packages/ui-default/build --iconfont",
         "build:ui:dev": "node packages/ui-default/build --iconfont && node --trace-deprecation packages/ui-default/build --dev",
         "build:ui:dev:https": "node packages/ui-default/build --iconfont && node --trace-deprecation packages/ui-default/build --dev --https",
-        "build:ui:production": "cross-env NODE_OPTIONS=--max_old_space_size=8192 node packages/ui-default/build --iconfont && node packages/ui-default/build --production",
+        "build:ui:production": "cross-env-shell NODE_OPTIONS=--max_old_space_size=8192 \"node packages/ui-default/build --iconfont && node packages/ui-default/build --production\"",
         "build:ui:production:webpack": "cross-env NODE_OPTIONS=--max_old_space_size=8192 node packages/ui-default/build --production",
         "test": "node -r @hydrooj/register packages/common/tests/subtask.spec.ts && node test/entry.js",
         "benchmark": "cross-env BENCHMARK=true node test/entry.js",


### PR DESCRIPTION
Fix OOM when `build:ui:production`. The command running after `&&` does not have increased memory limit, causing OOM errors. 

```text
$ node --version
v22.13.1
$ yarn build:ui:production
...
<--- Last few GCs --->

[11761:0xffffb8040000]    50158 ms: Scavenge (interleaved) 2030.7 (2082.1) -> 2026.5 (2084.1) MB, pooled: 0 MB, 10.23 / 0.00 ms  (average mu = 0.499, current mu = 0.290) allocation failure; 
[11761:0xffffb8040000]    50184 ms: Scavenge (interleaved) 2032.7 (2084.1) -> 2028.3 (2101.8) MB, pooled: 0 MB, 21.37 / 0.00 ms  (average mu = 0.499, current mu = 0.290) allocation failure; 


<--- JS stacktrace --->

FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
----- Native stack trace -----
...
```