### PR TITLE
judge: fix submission dispose too early & make submit_answer more efficient

### DIFF
--- a/packages/hydrojudge/src/judge/submit_answer.ts
+++ b/packages/hydrojudge/src/judge/submit_answer.ts
@@ -21,25 +21,24 @@ function judgeCase(c: NormalizedCase) {
         };
         if (ctx.config.subType === 'multi') {
             const res = await runQueued(
-                '/usr/bin/unzip foo.zip',
+                `/usr/bin/unzip -p foo.zip ${name}`,
                 {
                     stdin: null,
                     copyIn: { 'foo.zip': ctx.code },
-                    copyOutCached: [`${name}?`],
                     time: 1000,
                     memory: 128,
                     cacheStdoutAndStderr: true,
                 },
             );
             cleanup.clean = async () => await res[Symbol.asyncDispose]();
-            if (res.status === STATUS.STATUS_RUNTIME_ERROR && res.code) {
+            if (res.status === STATUS.STATUS_RUNTIME_ERROR && res.code && res.code !== 11) {
                 message = { message: 'Unzip failed.' };
                 status = STATUS.STATUS_WRONG_ANSWER;
-            } else if (!res.fileIds[name]) {
+            } else if (res.status === STATUS.STATUS_RUNTIME_ERROR && res.code && res.code === 11) {
                 message = { message: 'File not found.' };
                 status = STATUS.STATUS_WRONG_ANSWER;
             }
-            file = { fileId: res.fileIds[name] };
+            file = { fileId: res.fileIds['stdout'] };
         }
         if (status === STATUS.STATUS_ACCEPTED) {
             ({ status, score, message } = await checkers[ctx.config.checker_type]({

--- a/packages/hydrojudge/src/judge/submit_answer.ts
+++ b/packages/hydrojudge/src/judge/submit_answer.ts
@@ -15,8 +15,12 @@ function judgeCase(c: NormalizedCase) {
         let status = STATUS.STATUS_ACCEPTED;
         let message: any = '';
         let score = 0;
+        await using cleanup = {
+            clean: async () => { },
+            async [Symbol.asyncDispose]() { await this.clean(); },
+        };
         if (ctx.config.subType === 'multi') {
-            await using res = await runQueued(
+            const res = await runQueued(
                 '/usr/bin/unzip foo.zip',
                 {
                     stdin: null,
@@ -27,6 +31,7 @@ function judgeCase(c: NormalizedCase) {
                     cacheStdoutAndStderr: true,
                 },
             );
+            cleanup.clean = async () => await res[Symbol.asyncDispose]();
             if (res.status === STATUS.STATUS_RUNTIME_ERROR && res.code) {
                 message = { message: 'Unzip failed.' };
                 status = STATUS.STATUS_WRONG_ANSWER;


### PR DESCRIPTION
- `submit_answer` used the file outside of the block, causing `dispose` invoked too early. This commit fixed by introduce a disposable stack outside of the block
- make it more effifient by `unzip -p xx.zip name` to extract single file only, tather than whole zip. If the file not exists, the `unzip` returns `11`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced asynchronous operation handling for improved cleanup and background task management. These improvements ensure that processes complete more reliably and efficiently, contributing to a more stable and responsive system experience for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->