### PR TITLE
ui: fix table color in dark theme (fix #915)

### DIFF
--- a/packages/ui-default/theme/dark.styl
+++ b/packages/ui-default/theme/dark.styl
@@ -405,3 +405,6 @@ $hover-background-color = #424242
 
   &.hasjs .collapsed #status:not([data-status="7"]) .compiler-text-mask
     background-image: linear-gradient(to bottom, transparent, #000000 25px)
+
+  .page--record_detail .subtask
+    background-color: #000 !important

--- a/packages/ui-default/theme/dark.styl
+++ b/packages/ui-default/theme/dark.styl
@@ -221,7 +221,7 @@ $hover-background-color = #424242
     background-color: rgb(30, 30, 30)
 
   .typo table th, .typo table td, .typo table caption
-    border-color: #323232
+    border-color: #666
     color: #999
 
   body>.marker


### PR DESCRIPTION
This pull request includes changes to the `packages/ui-default/theme/dark.styl` file to update the border color of table elements and add a new background color for subtasks in the record detail page.

Styling updates:

* [`packages/ui-default/theme/dark.styl`](diffhunk://#diff-6b350b7f83fe16b4fed9056b7ef653e4c8fcb1e1649ac1927d9b58730ac7ba62L224-R224): Changed the border color of table elements from `#323232` to `#666`.
* [`packages/ui-default/theme/dark.styl`](diffhunk://#diff-6b350b7f83fe16b4fed9056b7ef653e4c8fcb1e1649ac1927d9b58730ac7ba62R408-R410): Added a new background color (`#000 !important`) for subtasks in the record detail page to ensure consistency with the dark theme.

|Before|After|
|:-|:-|
|![image](https://github.com/user-attachments/assets/15e1a1f5-1400-41eb-9aa4-0845a248c234)|![image](https://github.com/user-attachments/assets/284be95a-8e10-49d7-a6f7-3153a93d2f4d)|
|![image](https://github.com/user-attachments/assets/56b4f7bc-a544-4b3b-8bd0-8c40c7806f71)|![image](https://github.com/user-attachments/assets/c9c2b22c-9890-44ed-948e-fee79bbe6af8)|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Refined table visuals with lighter border tones.
	- Enhanced subtask presentation on record detail pages with updated background styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->