### PR TITLE
onsite-toolkit: remove duplicate organization entries to fix zip export

### DIFF
--- a/packages/onsite-toolkit/index.ts
+++ b/packages/onsite-toolkit/index.ts
@@ -113,7 +113,7 @@ export function apply(ctx: Context) {
                 const groupId = {};
                 let gid = 1;
                 for (const i of relatedGroups) groupId[i] = `group-${gid++}`;
-                const organizations = teams.flatMap((i) => i.organization);
+                const organizations = Array.from(new Set(teams.flatMap((i) => i.organization)));
                 const orgId = {};
                 let oid = 1;
                 for (const i of organizations) orgId[i] = `org-${oid++}`;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that organization lists no longer contain duplicate entries when generating organization-related event feeds and downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->