### PR TITLE
fix: prevent update root role in DomainPermissionHandler

### DIFF
--- a/packages/hydrooj/src/handler/domain.ts
+++ b/packages/hydrooj/src/handler/domain.ts
@@ -214,6 +214,7 @@ class DomainPermissionHandler extends ManageHandler {
     async post({ domainId }) {
         const roles = {};
         for (const role in this.request.body) {
+            if (role === 'root') continue; // root role is not editable
             const perms = this.request.body[role] instanceof Array
                 ? this.request.body[role]
                 : [this.request.body[role]];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the ability to edit or change permissions for the 'root' role through the permissions endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->