### PR TITLE
fix: User.serialize

### DIFF
--- a/packages/hydrooj/src/model/user.ts
+++ b/packages/hydrooj/src/model/user.ts
@@ -159,7 +159,7 @@ export class User {
         return user;
     }
 
-    serialize(_, h) {
+    serialize(h) {
         if (!this._isPrivate) {
             const fields = ['_id', 'uname', 'mail', 'perm', 'role', 'priv', 'regat', 'loginat', 'tfa', 'authn'];
             if (h?.user?.hasPerm(PERM.PERM_VIEW_DISPLAYNAME)) fields.push('displayName');


### PR DESCRIPTION
In `framework/framework/serializer.ts` , only one parameter is passed when `serialize()` is called, so the corresponding function definition is corrected here so that it can run correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No end-user facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->