### PR TITLE
core: fix contest ghost export

### DIFF
--- a/packages/hydrooj/src/handler/contest.ts
+++ b/packages/hydrooj/src/handler/contest.ts
@@ -806,7 +806,7 @@ export async function apply(ctx: Context) {
                     `@contest "${escape(tdoc.title)}"`,
                     `@contlen ${Math.floor((tdoc.endAt.getTime() - tdoc.beginAt.getTime()) / Time.minute)}`,
                     `@problems ${tdoc.pids.length}`,
-                    `@teams ${tdoc.attend + 100}`,
+                    `@teams ${tdoc.attend}`,
                     `@submissions ${submissions.length}`,
                 ].concat(
                     tdoc.pids.map((i, idx) => `@p ${pid(idx)},${escape(pdict[i]?.title || 'Unknown Problem')},20,0`),
@@ -815,7 +815,6 @@ export async function apply(ctx: Context) {
                         const teamName = `${i.rank ? '*' : ''}${escape(udict[i.uid].school || unknownSchool)}-${escape(showName)}`;
                         return `@t ${idx + 1},0,1,"${teamName}"`;
                     }),
-                    Array(100).fill(0).map((_, idx) => `@t ${tdoc.attend + idx + 1},0,1,"Пополнить команду"`),
                     submissions,
                 );
                 this.binary(res.join('\n'), `${this.tdoc.title}.ghost`);

--- a/packages/hydrooj/src/handler/contest.ts
+++ b/packages/hydrooj/src/handler/contest.ts
@@ -786,7 +786,7 @@ export async function apply(ctx: Context) {
                 const escape = (i: string) => i.replace(/[",]/g, '');
                 const unknownSchool = this.translate('Unknown School');
                 const statusMap = {
-                    [STATUS.STATUS_ACCEPTED]: 'AC',
+                    [STATUS.STATUS_ACCEPTED]: 'OK',
                     [STATUS.STATUS_WRONG_ANSWER]: 'WA',
                     [STATUS.STATUS_COMPILE_ERROR]: 'CE',
                     [STATUS.STATUS_TIME_LIMIT_EXCEEDED]: 'TL',
@@ -806,14 +806,15 @@ export async function apply(ctx: Context) {
                     `@contest "${escape(tdoc.title)}"`,
                     `@contlen ${Math.floor((tdoc.endAt.getTime() - tdoc.beginAt.getTime()) / Time.minute)}`,
                     `@problems ${tdoc.pids.length}`,
-                    `@teams ${tdoc.attend}`,
+                    `@teams ${tdoc.attend + 100}`,
                     `@submissions ${submissions.length}`,
                 ].concat(
                     tdoc.pids.map((i, idx) => `@p ${pid(idx)},${escape(pdict[i]?.title || 'Unknown Problem')},20,0`),
                     teams.map((i, idx) => {
-                        const teamName = `${i.rank ? '*' : ''}${escape(udict[i.uid].school || unknownSchool)}-${escape(udict[i.uid].uname)}`;
-                        return `@t ${idx + 1},0,1,${teamName}`;
+                        const teamName = `${i.rank ? '*' : ''}${escape(udict[i.uid].school || unknownSchool)}-${escape(udict[i.uid].displayName || udict[i.uid].uname)}`;
+                        return `@t ${idx + 1},0,1,"${teamName}"`;
                     }),
+                    Array(100).fill(0).map((_, idx) => `@t ${tdoc.attend + idx + 1},0,1,"Пополнить команду"`),
                     submissions,
                 );
                 this.binary(res.join('\n'), `${this.tdoc.title}.ghost`);

--- a/packages/hydrooj/src/handler/contest.ts
+++ b/packages/hydrooj/src/handler/contest.ts
@@ -811,7 +811,8 @@ export async function apply(ctx: Context) {
                 ].concat(
                     tdoc.pids.map((i, idx) => `@p ${pid(idx)},${escape(pdict[i]?.title || 'Unknown Problem')},20,0`),
                     teams.map((i, idx) => {
-                        const teamName = `${i.rank ? '*' : ''}${escape(udict[i.uid].school || unknownSchool)}-${escape(udict[i.uid].displayName || udict[i.uid].uname)}`;
+                        const showName = this.user.hasPerm(PERM.PERM_VIEW_DISPLAYNAME) ? (udict[i.uid].displayName || udict[i.uid].uname) : udict[i.uid].uname;
+                        const teamName = `${i.rank ? '*' : ''}${escape(udict[i.uid].school || unknownSchool)}-${escape(showName)}`;
                         return `@t ${idx + 1},0,1,"${teamName}"`;
                     }),
                     Array(100).fill(0).map((_, idx) => `@t ${tdoc.attend + idx + 1},0,1,"Пополнить команду"`),

--- a/packages/hydrooj/src/handler/contest.ts
+++ b/packages/hydrooj/src/handler/contest.ts
@@ -811,7 +811,7 @@ export async function apply(ctx: Context) {
                 ].concat(
                     tdoc.pids.map((i, idx) => `@p ${pid(idx)},${escape(pdict[i]?.title || 'Unknown Problem')},20,0`),
                     teams.map((i, idx) => {
-                        const showName = this.user.hasPerm(PERM.PERM_VIEW_DISPLAYNAME) ? (udict[i.uid].displayName || udict[i.uid].uname) : udict[i.uid].uname;
+                        const showName = this.user.hasPerm(PERM.PERM_VIEW_DISPLAYNAME) && udict[i.uid].displayName ? udict[i.uid].displayName : udict[i.uid].uname;
                         const teamName = `${i.rank ? '*' : ''}${escape(udict[i.uid].school || unknownSchool)}-${escape(showName)}`;
                         return `@t ${idx + 1},0,1,"${teamName}"`;
                     }),

--- a/packages/hydrooj/src/handler/contest.ts
+++ b/packages/hydrooj/src/handler/contest.ts
@@ -811,7 +811,8 @@ export async function apply(ctx: Context) {
                 ].concat(
                     tdoc.pids.map((i, idx) => `@p ${pid(idx)},${escape(pdict[i]?.title || 'Unknown Problem')},20,0`),
                     teams.map((i, idx) => {
-                        const showName = this.user.hasPerm(PERM.PERM_VIEW_DISPLAYNAME) && udict[i.uid].displayName ? udict[i.uid].displayName : udict[i.uid].uname;
+                        const showName = this.user.hasPerm(PERM.PERM_VIEW_DISPLAYNAME) && udict[i.uid].displayName
+                            ? udict[i.uid].displayName : udict[i.uid].uname;
                         const teamName = `${i.rank ? '*' : ''}${escape(udict[i.uid].school || unknownSchool)}-${escape(showName)}`;
                         return `@t ${idx + 1},0,1,"${teamName}"`;
                     }),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added 100 extra placeholder teams named "Пополнить команду" to the scoreboard view, each with a unique team ID.
- **Improvements**
  - User display names are now shown in the team list if available and permitted, with team names displayed in double quotes.
- **Bug Fixes**
  - Status code for accepted submissions in the scoreboard view changed from "AC" to "OK".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->