### PR TITLE
core&ui: fix contest with more than 26 problems have wrong alphabetic id

### DIFF
--- a/packages/hydrooj/src/handler/contest.ts
+++ b/packages/hydrooj/src/handler/contest.ts
@@ -6,6 +6,7 @@ import moment from 'moment-timezone';
 import { ObjectId } from 'mongodb';
 import {
     Counter, diffArray, randomstring, sortFiles, Time, yaml,
+    getContestProblemAlphabeticId
 } from '@hydrooj/utils/lib/utils';
 import { Context, Service } from '../context';
 import {
@@ -132,7 +133,7 @@ export class ContestDetailBaseHandler extends Handler {
             },
             {
                 name: 'problem_detail',
-                displayName: `${String.fromCharCode(65 + this.tdoc.pids.indexOf(pdoc.docId))}. ${pdoc.title}`,
+                displayName: `${getContestProblemAlphabeticId(this.tdoc.pids.indexOf(pdoc.docId))}. ${pdoc.title}`,
                 args: { query: { tid }, pid: pdoc.docId, prefix: 'contest_detail_problem' },
                 checker: () => 'pdoc' in this,
             },
@@ -791,7 +792,7 @@ export async function apply(ctx: Context) {
                 const teamIds: Record<number, number> = {};
                 for (let i = 1; i <= teams.length; i++) teamIds[teams[i - 1].uid] = i;
                 const time = (t: ObjectId) => Math.floor((t.getTimestamp().getTime() - tdoc.beginAt.getTime()) / Time.second);
-                const pid = (i: number) => String.fromCharCode(65 + i);
+                const pid = (i: number) => getContestProblemAlphabeticId(i);
                 const escape = (i: string) => i.replace(/[",]/g, '');
                 const unknownSchool = this.translate('Unknown School');
                 const statusMap = {

--- a/packages/hydrooj/src/handler/contest.ts
+++ b/packages/hydrooj/src/handler/contest.ts
@@ -4,10 +4,8 @@ import { stringify as toCSV } from 'csv-stringify/sync';
 import { escapeRegExp, pick } from 'lodash';
 import moment from 'moment-timezone';
 import { ObjectId } from 'mongodb';
-import {
-    Counter, diffArray, randomstring, sortFiles, Time, yaml,
-    getContestProblemAlphabeticId
-} from '@hydrooj/utils/lib/utils';
+import { Counter, diffArray, randomstring, sortFiles, Time, yaml } from '@hydrooj/utils/lib/utils';
+import { getContestProblemAlphabeticId } from '@hydrooj/utils/lib/broswer-can-use';
 import { Context, Service } from '../context';
 import {
     BadRequestError, ContestNotAttendedError, ContestNotEndedError, ContestNotFoundError, ContestNotLiveError,

--- a/packages/hydrooj/src/model/contest.ts
+++ b/packages/hydrooj/src/model/contest.ts
@@ -1,6 +1,9 @@
 import { sumBy } from 'lodash';
 import { Filter, ObjectId } from 'mongodb';
-import { Counter, formatSeconds, Time } from '@hydrooj/utils/lib/utils';
+import { 
+    Counter, formatSeconds, Time,
+    getContestProblemAlphabeticId
+} from '@hydrooj/utils/lib/utils';
 import {
     ContestAlreadyAttendedError, ContestNotFoundError,
     ContestScoreboardHiddenError, ValidationError,
@@ -158,7 +161,7 @@ const acm = buildContestRule({
             } else {
                 columns.push({
                     type: 'problem',
-                    value: String.fromCharCode(65 + i - 1),
+                    value: getContestProblemAlphabeticId(i - 1),
                     raw: pid,
                 });
             }
@@ -324,7 +327,7 @@ const oi = buildContestRule({
             } else {
                 columns.push({
                     type: 'problem',
-                    value: String.fromCharCode(65 + i - 1),
+                    value: getContestProblemAlphabeticId(i - 1),
                     raw: tdoc.pids[i - 1],
                 });
             }
@@ -699,7 +702,7 @@ const homework = buildContestRule({
             } else {
                 columns.push({
                     type: 'problem',
-                    value: String.fromCharCode(65 + i - 1),
+                    value: getContestProblemAlphabeticId(i - 1),
                     raw: pid,
                 });
             }

--- a/packages/hydrooj/src/model/contest.ts
+++ b/packages/hydrooj/src/model/contest.ts
@@ -1,9 +1,7 @@
 import { sumBy } from 'lodash';
 import { Filter, ObjectId } from 'mongodb';
-import { 
-    Counter, formatSeconds, Time,
-    getContestProblemAlphabeticId
-} from '@hydrooj/utils/lib/utils';
+import { Counter, formatSeconds, Time } from '@hydrooj/utils/lib/utils';
+import { getContestProblemAlphabeticId } from '@hydrooj/utils/lib/broswer-can-use';
 import {
     ContestAlreadyAttendedError, ContestNotFoundError,
     ContestScoreboardHiddenError, ValidationError,

--- a/packages/ui-default/backendlib/template.ts
+++ b/packages/ui-default/backendlib/template.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import * as status from '@hydrooj/common/status';
-import { findFileSync } from '@hydrooj/utils/lib/utils';
+import { findFileSync, getContestProblemAlphabeticId } from '@hydrooj/utils/lib/utils';
 import {
   avatar, Context, difficultyAlgorithm, fs, PERM, PRIV, Service, STATUS, yaml,
 } from 'hydrooj';
@@ -217,6 +217,7 @@ export class TemplateService extends Service {
     const env = new Nunjucks(Loader);
     env.addGlobal('findSubModule', (prefix) => Object.keys(that.registry).filter((n) => n.startsWith(prefix)));
     env.addGlobal('templateExists', (name) => !!that.registry[name]);
+    env.addGlobal('getContestProblemAlphabeticId', getContestProblemAlphabeticId)
 
     const render = (name: string, state: any) => new Promise<string>((resolve, reject) => {
       const start = Date.now();

--- a/packages/ui-default/backendlib/template.ts
+++ b/packages/ui-default/backendlib/template.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import * as status from '@hydrooj/common/status';
-import { findFileSync, getContestProblemAlphabeticId } from '@hydrooj/utils/lib/utils';
+import { findFileSync } from '@hydrooj/utils/lib/utils';
+import { getContestProblemAlphabeticId } from '@hydrooj/utils/lib/broswer-can-use';
 import {
   avatar, Context, difficultyAlgorithm, fs, PERM, PRIV, Service, STATUS, yaml,
 } from 'hydrooj';

--- a/packages/ui-default/pages/contest_balloon.page.tsx
+++ b/packages/ui-default/pages/contest_balloon.page.tsx
@@ -8,7 +8,7 @@ import { NamedPage } from 'vj/misc/Page';
 import {
   i18n, pjax, request, tpl,
 } from 'vj/utils';
-import { getContestProblemAlphabeticId } from '@hydrooj/utils';
+import { getContestProblemAlphabeticId } from '@hydrooj/utils/lib/broswer-can-use';
 
 function Balloon({ tdoc, val }) {
   const [color, setColor] = React.useState('');

--- a/packages/ui-default/pages/contest_balloon.page.tsx
+++ b/packages/ui-default/pages/contest_balloon.page.tsx
@@ -8,6 +8,7 @@ import { NamedPage } from 'vj/misc/Page';
 import {
   i18n, pjax, request, tpl,
 } from 'vj/utils';
+import { getContestProblemAlphabeticId } from '@hydrooj/utils';
 
 function Balloon({ tdoc, val }) {
   const [color, setColor] = React.useState('');
@@ -31,8 +32,8 @@ function Balloon({ tdoc, val }) {
                 <tr key={pid}>
                   <td>
                     {now === pid
-                      ? (<b>{String.fromCharCode(65 + tdoc.pids.indexOf(+pid))}</b>)
-                      : (<span>{String.fromCharCode(65 + tdoc.pids.indexOf(+pid))}</span>)}
+                      ? (<b>{getContestProblemAlphabeticId(tdoc.pids.indexOf(+pid))}</b>)
+                      : (<span>{getContestProblemAlphabeticId(tdoc.pids.indexOf(+pid))}</span>)}
                   </td>
                   <td>
                     <HexColorInput

--- a/packages/ui-default/templates/components/contest.html
+++ b/packages/ui-default/templates/components/contest.html
@@ -8,5 +8,5 @@
 {% endmacro %}
 
 {% macro render_clarification_subject(tdoc, pdict, subject) %}
-{% if subject == 0 %}{{ _('General Issue') }}{% elif subject == -1 %}{{ _('Technical Issue') }}{% else %}{{ String.fromCharCode(65 + tdoc.pids.indexOf(subject)) + 1 }}. {{ pdict[subject].title }}{% endif %}
+{% if subject == 0 %}{{ _('General Issue') }}{% elif subject == -1 %}{{ _('Technical Issue') }}{% else %}{{ getContestProblemAlphabeticId(tdoc.pids.indexOf(subject)) + 1 }}. {{ pdict[subject].title }}{% endif %}
 {% endmacro %}

--- a/packages/ui-default/templates/components/problem.html
+++ b/packages/ui-default/templates/components/problem.html
@@ -5,7 +5,7 @@
   <a href="{{ url('problem_detail', _linkArgs) }}"{% if small %} data-tooltip="{{ pdoc.title }}"{% endif %}>
 {%- endif -%}
 {% if show_pid %}
-<b>{%- if tdoc and alphabetic -%}{{ String.fromCharCode(65+tdoc.pids.indexOf(pdoc.docId)) }}
+<b>{%- if tdoc and alphabetic -%}{{ getContestProblemAlphabeticId(tdoc.pids.indexOf(pdoc.docId)) }}
 {%- elif pdoc.pid and pdoc.pid.includes('-') -%}{{ pdoc.pid.split('-').join('#') }}
 {%- else -%}{{ pdoc.pid|default(pdoc.docId) }}{%- endif -%}</b>
 {% endif %}

--- a/packages/ui-default/templates/contest_manage.html
+++ b/packages/ui-default/templates/contest_manage.html
@@ -127,7 +127,7 @@
                         <option value="0">{{ _('General Issue') }}</option>
                         <option value="-1">{{ _('Technical Issue') }}</option>
                         {% for pid in tdoc.pids %}
-                        <option value="{{ pid }}">{{ String.fromCharCode(65+loop.index0) }}. {{ pdict[pid].title }}</option>
+                        <option value="{{ pid }}">{{ getContestProblemAlphabeticId(loop.index0) }}. {{ pdict[pid].title }}</option>
                         {% endfor %}
                       </select>
                     </label>

--- a/packages/ui-default/templates/contest_problemlist.html
+++ b/packages/ui-default/templates/contest_problemlist.html
@@ -185,7 +185,7 @@
                   <option value="0">{{ _('General Issue') }}</option>
                   <option value="-1">{{ _('Technical Issue') }}</option>
                   {% for pid in tdoc.pids %}
-                  <option value="{{ pid }}">{{ String.fromCharCode(65+loop.index0) }}. {{ pdict[pid].title }}</option>
+                  <option value="{{ pid }}">{{ getContestProblemAlphabeticId(loop.index0) }}. {{ pdict[pid].title }}</option>
                   {% endfor %}
                 </select>
               </label>

--- a/packages/ui-default/templates/partials/contest_balloon.html
+++ b/packages/ui-default/templates/partials/contest_balloon.html
@@ -25,7 +25,7 @@
           </button> 
         </form>
       {% endif %}
-      <b>{{ String.fromCharCode(65+tdoc.pids.indexOf(bdoc.pid)) }}</b>&nbsp;&nbsp;({{ tdoc.balloon[bdoc.pid].name }})
+      <b>{{ getContestProblemAlphabeticId(tdoc.pids.indexOf(bdoc.pid)) }}</b>&nbsp;&nbsp;({{ tdoc.balloon[bdoc.pid].name }})
     </td>
     <td class="col--submit-by" data-tooltip="{{ bdoc._id.getTimestamp().format() }}">{{ user.render_inline(udict[bdoc.uid], badge=false) }}</td>
     <td class="col--send-by"{% if bdoc.sent %} data-tooltip="{{ bdoc.sentAt.format() }}"{% endif %}>

--- a/packages/ui-default/templates/problem_detail.html
+++ b/packages/ui-default/templates/problem_detail.html
@@ -64,7 +64,7 @@
             </form>
           {% endif %}
           {%- if tdoc -%}
-            {{ String.fromCharCode(65+tdoc.pids.indexOf(pdoc.docId)) }}
+            {{ getContestProblemAlphabeticId(tdoc.pids.indexOf(pdoc.docId)) }}
           {%- elif pdoc.pid and pdoc.pid.includes('-') -%}
             {{ pdoc.pid.split('-').join('#') }}
           {%- else -%}
@@ -80,7 +80,7 @@
               <a href="{{ url('problem_detail', pid=pid, query={tid:tdoc.docId}) }}"
                  class="{% if pass %}pass{% elif fail %}fail{% endif %}
                         {% if pid==pdoc.docId %} active{% endif %}">
-                <span class="id">{{ String.fromCharCode(65+loop.index0) }}</span>
+                <span class="id">{{ getContestProblemAlphabeticId(loop.index0) }}</span>
                 {% if status %}<span class="icon icon-{% if pass %}check{% else %}close{% endif %}"></span>{% endif %}
               </a>
             {%- endfor %}

--- a/packages/utils/lib/broswer-can-use.ts
+++ b/packages/utils/lib/broswer-can-use.ts
@@ -1,0 +1,12 @@
+export function getContestProblemAlphabeticId(index: number) {
+  // A...Z, AA...AZ, BA...BZ, ...
+  if (index < 0) return '?';
+  let letters = '';
+  index ++;
+  while (index > 0) {
+    index--;
+    letters = String.fromCharCode(65 + (index % 26)) + letters;
+    index = Math.floor(index / 26);
+  }
+  return letters;
+}

--- a/packages/utils/lib/utils.ts
+++ b/packages/utils/lib/utils.ts
@@ -397,4 +397,17 @@ export async function pipeRequest(req: superagent.Request, w: fs.WriteStream, ti
     }
 }
 
+export function getContestProblemAlphabeticId(index: number) {
+  // A...Z, AA...AZ, BA...BZ, ...
+  if (index < 0) return '?';
+  let letters = '';
+  index ++;
+  while (index > 0) {
+    index--;
+    letters = String.fromCharCode(65 + (index % 26)) + letters;
+    index = Math.floor(index / 26);
+  }
+  return letters;
+}
+
 export * from '@hydrooj/utils/lib/common';

--- a/packages/utils/lib/utils.ts
+++ b/packages/utils/lib/utils.ts
@@ -397,17 +397,4 @@ export async function pipeRequest(req: superagent.Request, w: fs.WriteStream, ti
     }
 }
 
-export function getContestProblemAlphabeticId(index: number) {
-  // A...Z, AA...AZ, BA...BZ, ...
-  if (index < 0) return '?';
-  let letters = '';
-  index ++;
-  while (index > 0) {
-    index--;
-    letters = String.fromCharCode(65 + (index % 26)) + letters;
-    index = Math.floor(index / 26);
-  }
-  return letters;
-}
-
 export * from '@hydrooj/utils/lib/common';


### PR DESCRIPTION
When a contest have more than 26 problems, the alphabetic id will have problem.

Why contest have so many problems? Some teacher likes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a utility function to generate alphabetic problem identifiers (e.g., A, B, ..., Z, AA, AB, etc.) for contests.

* **Refactor**
  * Updated all relevant user interfaces and templates to use the new utility function for displaying contest problem IDs, ensuring consistent labeling across the platform.

* **Documentation**
  * No user-facing documentation changes included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->