### PR TITLE
fix admin can not view all related contest

### DIFF
--- a/packages/hydrooj/src/handler/problem.ts
+++ b/packages/hydrooj/src/handler/problem.ts
@@ -392,7 +392,7 @@ export class ProblemDetailHandler extends ContestDetailBaseHandler {
                 contest.getRelated(this.args.domainId, this.pdoc.docId),
                 contest.getRelated(this.args.domainId, this.pdoc.docId, 'homework'),
             ])).map((tdocs) => tdocs.filter((tdoc) =>
-                this.user.hasPerm(PERM.PERM_VIEW_CONTEST) || !tdoc.assign?.length || Set.intersection(tdoc.assign, this.user.group).size,
+                this.user.hasPerm(PERM.PERM_VIEW_HIDDEN_CONTEST) || !tdoc.assign?.length || Set.intersection(tdoc.assign, this.user.group).size,
             ));
         }
     }

--- a/packages/hydrooj/src/handler/problem.ts
+++ b/packages/hydrooj/src/handler/problem.ts
@@ -391,7 +391,9 @@ export class ProblemDetailHandler extends ContestDetailBaseHandler {
             [this.response.body.ctdocs, this.response.body.htdocs] = (await Promise.all([
                 contest.getRelated(this.args.domainId, this.pdoc.docId),
                 contest.getRelated(this.args.domainId, this.pdoc.docId, 'homework'),
-            ])).map((tdocs) => tdocs.filter((tdoc) => !tdoc.assign?.length || Set.intersection(tdoc.assign, this.user.group).size));
+            ])).map((tdocs) => tdocs.filter((tdoc) =>
+                this.user.hasPerm(PERM.PERM_VIEW_CONTEST) || !tdoc.assign?.length || Set.intersection(tdoc.assign, this.user.group).size,
+            ));
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users with specific permissions can now access more related contest and homework documents for a problem.

* **Bug Fixes**
  * Improved filtering logic to ensure users with appropriate permissions see all relevant documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->