### PR TITLE
devcontainer: bump node version to 22 and update feature installation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,9 @@
 FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:22-bookworm
 
-RUN mkdir -p /root/.hydro /data/file && \
-    chown -R root:root /root /root/.hydro /data/file && \
-    echo '{"uri":"mongodb://mongo/hydro"}' > /root/.hydro/config.json && \
-    echo '["@hydrooj/ui-default","@hydrooj/hydrojudge"]' > /root/.hydro/addon.json
+RUN install -d -o root -g root /root/.hydro /data/file \
+    && cat <<'EOF' > /root/.hydro/config.json
+{"uri":"mongodb://mongo/hydro"}
+EOF \
+    && cat <<'EOF' > /root/.hydro/addon.json
+["@hydrooj/ui-default","@hydrooj/hydrojudge"]
+EOF

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,6 @@
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:20-bookworm
-ADD https://github.com/criyle/go-judge/releases/download/v1.8.0/go-judge_1.8.0_linux_amd64 /usr/bin/sandbox
-RUN npm install -g yarn && \
-    sudo apt-get update && sudo apt-get install gcc g++ && \
-    mkdir -p /root/.hydro /data/file && chmod +x /usr/bin/sandbox && \
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:22-bookworm
+
+RUN mkdir -p /root/.hydro /data/file && \
     chown -R root:root /root /root/.hydro /data/file && \
     echo '{"uri":"mongodb://mongo/hydro"}' > /root/.hydro/config.json && \
     echo '["@hydrooj/ui-default","@hydrooj/hydrojudge"]' > /root/.hydro/addon.json
-ENTRYPOINT sandbox

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,5 @@
 FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:22-bookworm
 
-RUN install -d -o root -g root /root/.hydro /data/file \
-    && cat <<'EOF' > /root/.hydro/config.json
-{"uri":"mongodb://mongo/hydro"}
-EOF \
-    && cat <<'EOF' > /root/.hydro/addon.json
-["@hydrooj/ui-default","@hydrooj/hydrojudge"]
-EOF
+RUN install -d -o root -g root /root/.hydro /data/file && \
+    echo '{"uri":"mongodb://mongo/hydro"}' > /root/.hydro/config.json && \
+    echo '["@hydrooj/ui-default","@hydrooj/hydrojudge"]' > /root/.hydro/addon.json

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,8 +9,6 @@
 				"dbaeumer.vscode-eslint",
 				"gruntfuggly.todo-tree",
 				"ronnidc.nunjucks",
-				"eamodio.gitlens",
-				"vscode-icons-team.vscode-icons",
 				"sysoev.language-stylus"
 			]
 		}
@@ -20,5 +18,19 @@
 		2333,
 		8000
 	],
+	"features": {
+		"ghcr.io/devcontainers-extra/features/gh-release:1": {
+			"repo": "criyle/go-judge",
+			"binaryNames": "go-judge",
+			"assetRegex": "go-judge_.*\\.tar\\.gz"
+		},
+		"ghcr.io/devcontainers-extra/features/apt-packages:1": {
+			"packages": [
+				"gcc",
+				"g++"
+			]
+		},
+		"ghcr.io/devcontainers/features/node:1": {}
+	},
 	"postCreateCommand": "git submodule update --init && yarn install && npx hydrooj cli system set server.port 2333 && npx hydrooj cli user create root@hydro.local root rootroot 2 && npx hydrooj cli user setSuperAdmin 2"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,8 +29,7 @@
 				"gcc",
 				"g++"
 			]
-		},
-		"ghcr.io/devcontainers/features/node:1": {}
+		}
 	},
 	"postCreateCommand": "git submodule update --init && yarn install && npx hydrooj cli system set server.port 2333 && npx hydrooj cli user create root@hydro.local root rootroot 2 && npx hydrooj cli user setSuperAdmin 2"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mongo:
-    image: mongo:latest
+    image: mongo:8
     restart: unless-stopped
     volumes:
       - mongodb-data:/data/db

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,8 +1,6 @@
-version: '3.9'
-
 services:
   mongo:
-    image: mongo:4-focal
+    image: mongo:latest
     restart: unless-stopped
     volumes:
       - mongodb-data:/data/db
@@ -15,8 +13,11 @@ services:
       - mongo
     volumes:
       - ..:/workspace:cached
+      - node_modules:/workspace/node_modules
       - testdata:/data/file
+    command: go-judge
 
 volumes:
   mongodb-data:
+  node_modules:
   testdata:


### PR DESCRIPTION
- bump dev container version to 22
- use dev container feature `gh-release` to install sandbox and apt packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development container to use newer base images and simplified setup steps.
  * Replaced installation of certain binaries and packages with standardized devcontainer features.
  * Updated MongoDB service to use the latest image.
  * Removed two VS Code extensions from the recommended list.
  * Adjusted service startup commands and added volume mounts for improved development environment consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->