### PR TITLE
fix subtask column rendering in dark mode

### DIFF
--- a/packages/ui-default/pages/record_detail.page.styl
+++ b/packages/ui-default/pages/record_detail.page.styl
@@ -1,3 +1,7 @@
+// special for subtask columns in dark mode
+html.theme--dark.page--record_detail.subtask
+  background-color: #000 !important 
+
 .page--record_detail
 
   .compiler-text


### PR DESCRIPTION
Before:

<img width="665" height="239" alt="284" src="https://github.com/user-attachments/assets/69d55b6f-726e-4586-b106-8fa8be5f4ed0" />

After:

<img width="671" height="241" alt="285" src="https://github.com/user-attachments/assets/be05f506-7325-4a3f-ab91-d15696149c80" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dark mode visuals for subtasks on the record detail page, applying a true dark background for better contrast and readability.
  * Ensures subtask sections align with the overall dark theme, reducing glare and enhancing visual consistency.
  * Light mode appearance remains unchanged.
  * Change applies automatically when dark theme is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->