### PR TITLE
ui: fix ranking header opacity in dark mode

### DIFF
--- a/packages/ui-default/theme/dark.styl
+++ b/packages/ui-default/theme/dark.styl
@@ -93,7 +93,7 @@ $hover-background-color = #424242
     box-shadow: 0 0.125rem 0.625rem rgba(255 255 255 20%)
 
   .section__table-header
-    background-color: transparent
+    background-color: rgba(0, 0, 0, 0.95)
     box-shadow: 0 0.1875rem 0.125rem rgba(255 255 255 3%)
 
   .data-table tr


### PR DESCRIPTION
This time I must have fixed it in the right file.

Before:

<img width="895" height="390" alt="286" src="https://github.com/user-attachments/assets/24de9875-e595-4607-a79c-eb0eb6259a98" />

After:

<img width="893" height="389" alt="287" src="https://github.com/user-attachments/assets/1fccd2ce-67f3-42e5-ac81-84f93f58b0c2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dark theme table headers to use a near‑opaque black background, improving contrast, readability, and visual consistency—especially over busy or variable backgrounds.
  * Enhances focus and accessibility for data tables across the app where these headers appear.
  * Visual-only change: no impact to spacing, typography, sorting, or interactions is expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->