### PR TITLE
ui: fix ranking header opacity in dark mode

### DIFF
--- a/packages/ui-default/theme/dark.styl
+++ b/packages/ui-default/theme/dark.styl
@@ -93,7 +93,7 @@ $hover-background-color = #424242
     box-shadow: 0 0.125rem 0.625rem rgba(255 255 255 20%)
 
   .section__table-header
-    background-color: transparent
+    background-color: rgba($table-header-bg-color, 0.95)
     box-shadow: 0 0.1875rem 0.125rem rgba(255 255 255 3%)
 
   .data-table tr


### PR DESCRIPTION
Before:

<img width="895" height="390" alt="286" src="https://github.com/user-attachments/assets/0499f4d9-f7c4-45b1-863c-fa868ac0074d" />

After:

<img width="893" height="389" alt="287" src="https://github.com/user-attachments/assets/aa46611b-59c3-4a8c-96b6-3dcc59250ee9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the dark theme table header background to a semi-opaque tone, improving contrast, readability, and visual hierarchy across all tables.
  * Reduces content bleed-through beneath headers (especially during scrolling) for a cleaner, more focused look.
  * Maintains existing shadows and layout, ensuring visual consistency without affecting functionality or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->