### PR TITLE
docker: fix broken docker-compose file

### DIFF
--- a/install/docker/backend/Dockerfile
+++ b/install/docker/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:22
 
 COPY ./entrypoint.sh /root/entrypoint.sh
 

--- a/install/docker/docker-compose.yml
+++ b/install/docker/docker-compose.yml
@@ -2,18 +2,25 @@ services:
   # Warning: mongodb here is not password-protected.
   # DO NOT EXPOSE THIS SERVICE TO THE PUBLIC.
   oj-mongo:
-    image: mongo
+    image: mongo:7-jammy
     container_name: oj-mongo
     restart: always
     volumes:
       - ./data/mongo:/data/db
-
+    healthcheck:
+      test: mongosh --eval "db.adminCommand('ping')"
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
   oj-backend:
     build: ./backend
     container_name: oj-backend
     restart: always
     depends_on:
-      - oj-mongo
+      oj-mongo:
+        condition: service_healthy
+        restart: true
     volumes:
       - ./data/file:/data/file
       - ./data/backend:/root/.hydro

--- a/install/docker/judge/Dockerfile
+++ b/install/docker/judge/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:22
 
 COPY ./entrypoint.sh /root/entrypoint.sh
 


### PR DESCRIPTION
The docker-compose.yml file is currently broken due to a package requirement change. This PR fixes the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded runtime to Node.js 22 for backend and judge containers.
  * Upgraded database container to MongoDB 7.
  * Added health checks for backend and database to improve reliability and automatic recovery.
  * Enforced startup ordering so services wait for healthy dependencies.
  * Exposed backend on port 80 by default for simpler access.
  * Overall improves stability, observability, and startup behavior in Docker-based deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->