### PR TITLE
feat: support regex for objective problem

### DIFF
--- a/packages/common/types.ts
+++ b/packages/common/types.ts
@@ -51,7 +51,7 @@ export interface ProblemConfigFile {
     user_extra_files?: string[];
     judge_extra_files?: string[];
     detail?: DetailType | boolean;
-    answers?: Record<string, [string | string[], number]>;
+    answers?: Record<string, [string | string[], number, string]>;
     redirect?: string;
     cases?: TestCaseConfig[];
     subtasks?: SubtaskConfig[];

--- a/packages/hydrojudge/src/judge/objective.ts
+++ b/packages/hydrojudge/src/judge/objective.ts
@@ -32,7 +32,7 @@ export async function judge({
     const subtasks = {};
     if (!Object.keys(config.answers).length) throw new FormatError('Invalid standard answer.');
     for (const key in config.answers) {
-        const ansInfo = config.answers[key] as [string | string[], number] | Record<string, number>;
+        const ansInfo = config.answers[key] as [string | string[], number, string] | Record<string, number>;
         // eslint-disable-next-line ts/no-loop-func
         const report = (status: STATUS, score: number, message: string) => {
             const [subtaskId, caseId] = key.split('-').map(Number);
@@ -68,6 +68,10 @@ export async function judge({
                 const ans = new Set(answers[key] instanceof Array ? answers[key] : [answers[key]]);
                 if (stdAns.length === ans.size && Set.isSuperset(stdSet, ans)) report(STATUS.STATUS_ACCEPTED, fullScore, 'Correct');
                 else if (ans.size && Set.isSuperset(stdSet, ans)) report(STATUS.STATUS_WRONG_ANSWER, Math.floor(fullScore / 2), 'Partially Correct');
+                else report(STATUS.STATUS_WRONG_ANSWER, 0, 'Incorrect');
+            } else if (ansInfo[2] === 'regex') {
+                const regex = new RegExp(stdAns);
+                if (regex.test(usrAns)) report(STATUS.STATUS_ACCEPTED, fullScore, 'Correct');
                 else report(STATUS.STATUS_WRONG_ANSWER, 0, 'Incorrect');
             } else if (stdAns.toString() === usrAns) report(STATUS.STATUS_ACCEPTED, fullScore, 'Correct');
             else report(STATUS.STATUS_WRONG_ANSWER, 0, 'Incorrect');


### PR DESCRIPTION
support regex for objective problem

problem config:

```yaml
type: objective
answers:
  '1':
  - .*(IntelliJ IDEA|Eclipse IDE|Electron:).*
  - 100
  - regex
```

matches

```plain
版本: 1.104.1 (Universal)
提交: 0f0d87fa9e96c856c5212fc86db137ac0d783365
日期: 2025-09-17T23:36:24.973Z
Electron: 37.3.1
ElectronBuildId: 12404162
Chromium: 138.0.7204.235
Node.js: 22.18.0
V8: 13.8.258.31-electron.0
OS: Darwin arm64 25.0.0
```