### PR TITLE
bugfix: ProblemAlreadyExistError

### DIFF
--- a/packages/hydrooj/src/handler/problem.ts
+++ b/packages/hydrooj/src/handler/problem.ts
@@ -616,7 +616,7 @@ export class ProblemEditHandler extends ProblemManageHandler {
         newPid: string | number = '', hidden = false, tag: string[] = [], difficulty = 0,
     ) {
         if (typeof newPid !== 'string') newPid = `P${newPid}`;
-        if (newPid !== this.pdoc.pid && await problem.get(domainId, newPid)) throw new ProblemAlreadyExistError(pid);
+        if (newPid !== this.pdoc.pid && await problem.get(domainId, newPid)) throw new ProblemAlreadyExistError(newPid);
         const $update: Partial<ProblemDoc> = {
             title, content, pid: newPid, hidden, tag: tag ?? [], difficulty, html: false,
         };


### PR DESCRIPTION
ProblemAlreadyExistError should be thrown with the new PID, not the old one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When renaming a problem to an ID that already exists, the conflict error now correctly shows the attempted new ID, not the original one.
  * This provides clearer feedback during edits, helping users quickly identify and resolve ID collisions without confusion.
  * Error messages and notifications will reflect the exact conflicting identifier, improving accuracy and usability during problem updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->