### PR TITLE
core: ProblemAlreadyExistError should be thrown with the new PID

### DIFF
--- a/packages/hydrooj/src/handler/problem.ts
+++ b/packages/hydrooj/src/handler/problem.ts
@@ -616,7 +616,7 @@ export class ProblemEditHandler extends ProblemManageHandler {
         newPid: string | number = '', hidden = false, tag: string[] = [], difficulty = 0,
     ) {
         if (typeof newPid !== 'string') newPid = `P${newPid}`;
-        if (newPid !== this.pdoc.pid && await problem.get(domainId, newPid)) throw new ProblemAlreadyExistError(pid);
+        if (newPid !== this.pdoc.pid && await problem.get(domainId, newPid)) throw new ProblemAlreadyExistError(newPid);
         const $update: Partial<ProblemDoc> = {
             title, content, pid: newPid, hidden, tag: tag ?? [], difficulty, html: false,
         };


### PR DESCRIPTION
ProblemAlreadyExistError should be thrown with the new PID, not the old one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the duplicate-problem validation to display the actual conflicting problem ID in the error message when creating or renaming a problem. This provides clearer feedback to users by indicating the exact ID that already exists, reducing confusion during problem management workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->