### PR TITLE
core: fix negative ntry in ledo scoreboard

### DIFF
--- a/packages/hydrooj/src/model/contest.ts
+++ b/packages/hydrooj/src/model/contest.ts
@@ -566,7 +566,7 @@ const ledo = buildContestRule({
                 detail[j.pid] = {
                     ...j,
                     penaltyScore,
-                    ntry: ntry[j.pid] - 1,
+                    ntry: Math.max(0, ntry[j.pid] - 1),
                 };
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed attempt counting in Ledo contests to prevent negative values, ensuring penalties are applied correctly.
  - Improved stability of penalty-based scoring to avoid unexpected score fluctuations.
  - Increased consistency and fairness of rankings for participants under the Ledo rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->