### PR TITLE
core: allow extra user private & public fields

### DIFF
--- a/packages/hydrooj/locales/zh.yaml
+++ b/packages/hydrooj/locales/zh.yaml
@@ -886,7 +886,7 @@ View Contest: 查看比赛
 View contests: 查看比赛
 View Details: 查看详情
 View discussions: 查看讨论
-View domain user displayname: 显示域中用户的显示名
+View domain user private info: 显示域中用户的私有信息
 View hidden contest submission status and scoreboard: 查看隐藏的比赛递交状态和成绩表
 View hidden homework submission status and scoreboard: 查看隐藏的作业递交状态和成绩表
 View hidden problems: 查看隐藏的题目

--- a/packages/hydrooj/src/handler/contest.ts
+++ b/packages/hydrooj/src/handler/contest.ts
@@ -221,12 +221,7 @@ export class ContestPrintHandler extends ContestDetailBaseHandler {
         const tasks = await contest.getMultiPrintTask(domainId, tid, isContestAdmin ? {} : { owner: this.user._id })
             .project({ _id: 1, title: 1, owner: 1, status: 1 }).sort({ _id: 1 }).toArray();
         const uids = Array.from(new Set(tasks.map((i) => i.owner)));
-        const udict = await user.getListForRender(
-            domainId, uids,
-            this.user.hasPerm(PERM.PERM_VIEW_DISPLAYNAME)
-                ? ['displayName', 'school', 'studentId']
-                : [],
-        );
+        const udict = await user.getListForRender(domainId, uids, this.user.hasPerm(PERM.PERM_VIEW_USER_PRIVATE_INFO));
         this.response.body = { tasks, udict };
     }
 
@@ -515,7 +510,7 @@ export class ContestManagementHandler extends ContestManagementBaseHandler {
             files: sortFiles(this.tdoc.files || []),
             udict: await user.getListForRender(
                 domainId, tcdocs.map((i) => i.owner),
-                this.user.hasPerm(PERM.PERM_VIEW_DISPLAYNAME) ? ['displayName'] : [],
+                this.user.hasPerm(PERM.PERM_VIEW_USER_PRIVATE_INFO),
             ),
             tcdocs,
             urlForFile: (filename: string) => this.url('contest_file_download', { tid, filename }),
@@ -627,7 +622,7 @@ export class ContestUserHandler extends ContestManagementBaseHandler {
         }
         const udict = await user.getListForRender(
             domainId, [this.tdoc.owner, ...tsdocs.map((i) => i.uid)],
-            this.user.hasPerm(PERM.PERM_VIEW_DISPLAYNAME) ? ['displayName'] : [],
+            this.user.hasPerm(PERM.PERM_VIEW_USER_PRIVATE_INFO),
         );
         this.response.body = { tdoc: this.tdoc, tsdocs, udict };
         this.response.pjax = 'partials/contest_user.html';
@@ -668,7 +663,7 @@ export class ContestBalloonHandler extends ContestManagementBaseHandler {
             owner_udoc: await user.getById(domainId, this.tdoc.owner),
             pdict: await problem.getList(domainId, this.tdoc.pids, true, true, problem.PROJECTION_CONTEST_LIST),
             bdocs,
-            udict: await user.getListForRender(domainId, uids, this.user.hasPerm(PERM.PERM_VIEW_DISPLAYNAME) ? ['displayName'] : []),
+            udict: await user.getListForRender(domainId, uids, this.user.hasPerm(PERM.PERM_VIEW_USER_PRIVATE_INFO)),
         };
         this.response.pjax = 'partials/contest_balloon.html';
         this.response.template = 'contest_balloon.html';
@@ -835,7 +830,7 @@ export async function apply(ctx: Context) {
                 if (realtime && !this.user.own(tdoc)) {
                     this.checkPerm(PERM.PERM_VIEW_CONTEST_HIDDEN_SCOREBOARD);
                 }
-                const config: ScoreboardConfig = { isExport: false, showDisplayName: this.user.hasPerm(PERM.PERM_VIEW_DISPLAYNAME) };
+                const config: ScoreboardConfig = { isExport: false, showDisplayName: this.user.hasPerm(PERM.PERM_VIEW_USER_PRIVATE_INFO) };
                 if (!realtime && this.tdoc.lockAt && !this.tdoc.unlocked) {
                     config.lockAt = this.tdoc.lockAt;
                 }
@@ -895,7 +890,7 @@ export async function apply(ctx: Context) {
                 ].concat(
                     tdoc.pids.map((i, idx) => `@p ${pid(idx)},${escape(pdict[i]?.title || 'Unknown Problem')},20,0`),
                     teams.map((i, idx) => {
-                        const showName = this.user.hasPerm(PERM.PERM_VIEW_DISPLAYNAME) && udict[i.uid].displayName
+                        const showName = this.user.hasPerm(PERM.PERM_VIEW_USER_PRIVATE_INFO) && udict[i.uid].displayName
                             ? udict[i.uid].displayName : udict[i.uid].uname;
                         const teamName = `${i.rank ? '*' : ''}${escape(udict[i.uid].school || unknownSchool)}-${escape(showName)}`;
                         return `@t ${idx + 1},0,1,"${teamName}"`;
@@ -910,7 +905,7 @@ export async function apply(ctx: Context) {
             async display({ tdoc }) {
                 await this.limitRate('scoreboard_download', 60, 3);
                 const [, rows] = await contest.getScoreboard.call(this, tdoc.domainId, tdoc._id, {
-                    isExport: true, lockAt: this.tdoc.lockAt, showDisplayName: this.user.hasPerm(PERM.PERM_VIEW_DISPLAYNAME),
+                    isExport: true, lockAt: this.tdoc.lockAt, showDisplayName: this.user.hasPerm(PERM.PERM_VIEW_USER_PRIVATE_INFO),
                 });
                 this.binary(await this.renderHTML('contest_scoreboard_download_html.html', { rows, tdoc }), `${this.tdoc.title}.html`);
             },
@@ -920,7 +915,7 @@ export async function apply(ctx: Context) {
             async display({ tdoc }) {
                 await this.limitRate('scoreboard_download', 60, 3);
                 const [, rows] = await contest.getScoreboard.call(this, tdoc.domainId, tdoc._id, {
-                    isExport: true, lockAt: this.tdoc.lockAt, showDisplayName: this.user.hasPerm(PERM.PERM_VIEW_DISPLAYNAME),
+                    isExport: true, lockAt: this.tdoc.lockAt, showDisplayName: this.user.hasPerm(PERM.PERM_VIEW_USER_PRIVATE_INFO),
                 });
                 this.binary(toCSV(rows.map((r) => r.map((c) => c.value.toString())), { bom: true }), `${this.tdoc.title}.csv`);
             },

--- a/packages/hydrooj/src/handler/domain.ts
+++ b/packages/hydrooj/src/handler/domain.ts
@@ -143,7 +143,7 @@ class DomainUserHandler extends ManageHandler {
                         user: 1,
                         role: 1,
                         join: 1,
-                        ...(this.user.hasPerm(PERM.PERM_VIEW_DISPLAYNAME) ? { displayName: 1 } : {}),
+                        ...(this.user.hasPerm(PERM.PERM_VIEW_USER_PRIVATE_INFO) ? { displayName: 1 } : {}),
                     },
                 },
             ]).toArray(),

--- a/packages/hydrooj/src/handler/problem.ts
+++ b/packages/hydrooj/src/handler/problem.ts
@@ -974,7 +974,7 @@ export class ProblemStatisticsHandler extends ProblemDetailHandler {
             'record',
         );
         const [udict, udoc] = await Promise.all([
-            user.getListForRender(domainId, rsdocs.map((i) => i.uid), this.user.hasPerm(PERM.PERM_VIEW_DISPLAYNAME) ? ['displayName'] : []),
+            user.getListForRender(domainId, rsdocs.map((i) => i.uid), this.user.hasPerm(PERM.PERM_VIEW_USER_PRIVATE_INFO)),
             user.getById(domainId, this.pdoc.owner),
         ]);
         this.response.template = 'problem_statistics.html';

--- a/packages/hydrooj/src/handler/training.ts
+++ b/packages/hydrooj/src/handler/training.ts
@@ -111,7 +111,7 @@ class TrainingDetailHandler extends Handler {
         const canViewHidden = this.user.hasPerm(PERM.PERM_VIEW_PROBLEM_HIDDEN) || this.user._id;
         const [udoc, udict, pdict, psdict, selfPsdict] = await Promise.all([
             user.getById(domainId, tdoc.owner),
-            user.getListForRender(domainId, enrollUsers, this.user.hasPerm(PERM.PERM_VIEW_DISPLAYNAME) ? ['displayName'] : []),
+            user.getListForRender(domainId, enrollUsers, this.user.hasPerm(PERM.PERM_VIEW_USER_PRIVATE_INFO)),
             problem.getList(domainId, pids, canViewHidden, true),
             problem.getListStatus(domainId, uid, pids),
             shouldCompare ? problem.getListStatus(domainId, this.user._id, pids) : {},

--- a/packages/hydrooj/src/model/builtin.ts
+++ b/packages/hydrooj/src/model/builtin.ts
@@ -12,7 +12,9 @@ export const PERM = {
     // Domain Settings
     PERM_VIEW: 1n << 0n,
     PERM_EDIT_DOMAIN: 1n << 1n,
+    /** @deprecated use PERM_VIEW_USER_PRIVATE_INFO instead */
     PERM_VIEW_DISPLAYNAME: 1n << 67n,
+    PERM_VIEW_USER_PRIVATE_INFO: 1n << 67n,
     PERM_MOD_BADGE: 1n << 2n,
 
     // Problem
@@ -105,7 +107,7 @@ export const Permission = (family: string, key: bigint, desc: string) => ({ fami
 
 export const PERMS = [
     Permission('perm_general', PERM.PERM_VIEW, 'View this domain'),
-    Permission('perm_general', PERM.PERM_VIEW_DISPLAYNAME, 'View domain user displayname'),
+    Permission('perm_general', PERM.PERM_VIEW_USER_PRIVATE_INFO, 'View domain user private info'),
     Permission('perm_general', PERM.PERM_EDIT_DOMAIN, 'Edit domain settings'),
     Permission('perm_general', PERM.PERM_MOD_BADGE, 'Show MOD badge'),
     Permission('perm_problem', PERM.PERM_CREATE_PROBLEM, 'Create problems'),
@@ -191,7 +193,7 @@ PERM.PERM_BASIC = PERM.PERM_VIEW
     | PERM.PERM_VIEW_RECORD;
 
 PERM.PERM_DEFAULT = PERM.PERM_VIEW
-    | PERM.PERM_VIEW_DISPLAYNAME
+    | PERM.PERM_VIEW_USER_PRIVATE_INFO
     | PERM.PERM_VIEW_PROBLEM
     | PERM.PERM_EDIT_PROBLEM_SELF
     | PERM.PERM_SUBMIT_PROBLEM

--- a/packages/hydrooj/src/model/setting.ts
+++ b/packages/hydrooj/src/model/setting.ts
@@ -31,6 +31,8 @@ export const FLAG_HIDDEN = 1;
 export const FLAG_DISABLED = 2;
 export const FLAG_SECRET = 4;
 export const FLAG_PRO = 8;
+export const FLAG_PUBLIC = 16;
+export const FLAG_PRIVATE = 32;
 
 export const PREFERENCE_SETTINGS: _Setting[] = [];
 export const ACCOUNT_SETTINGS: _Setting[] = [];
@@ -75,6 +77,7 @@ declare global {
         interface Meta<T> { // eslint-disable-line ts/no-unused-vars
             family?: string;
             secret?: boolean;
+            flag?: number;
         }
     }
 }
@@ -93,6 +96,7 @@ function schemaToSettings(schema: Schema<any>) {
                     : s.meta?.role === 'markdown' ? 'markdown'
                         : s.meta?.role === 'textarea' ? 'textarea' : 'text';
         if (s.meta?.role === 'password') flag |= FLAG_SECRET;
+        if (s.meta?.flag) flag |= s.meta?.flag;
         const options = {};
         for (const item of actualList || []) {
             if (item.type !== 'const') throw new Error(`List item must be a constant, got ${item.type}`);
@@ -256,9 +260,9 @@ AccountSetting(
     Setting('setting_info', 'qq', null, 'text', 'QQ'),
     Setting('setting_info', 'gender', builtin.USER_GENDER_OTHER, builtin.USER_GENDER_RANGE, 'Gender'),
     Setting('setting_info', 'bio', null, 'markdown', 'Bio'),
-    Setting('setting_info', 'school', '', 'text', 'School'),
-    Setting('setting_info', 'studentId', '', 'text', 'Student ID'),
-    Setting('setting_info', 'phone', null, 'text', 'Phone', null, FLAG_DISABLED),
+    Setting('setting_info', 'school', '', 'text', 'School', '', FLAG_PRIVATE),
+    Setting('setting_info', 'studentId', '', 'text', 'Student ID', '', FLAG_PRIVATE),
+    Setting('setting_info', 'phone', null, 'text', 'Phone', null, FLAG_PRIVATE),
     Setting('setting_customize', 'backgroundImage',
         '/components/profile/backgrounds/1.jpg', 'text', 'Profile Background Image',
         'Choose the background image in your profile page.'),
@@ -278,7 +282,8 @@ DomainSetting(
 );
 
 DomainUserSetting(Schema.object({
-    displayName: Schema.transform(String, (input) => saslPrep(input)).default('').description('Display Name').extra('family', 'setting_info'),
+    displayName: Schema.transform(String, (input) => saslPrep(input)).default('').description('Display Name')
+        .extra('family', 'setting_info').extra('flag', FLAG_PRIVATE),
 
     rpInfo: Schema.any().extra('family', 'setting_storage').disabled().hidden(),
 
@@ -415,6 +420,8 @@ global.Hydro.model.setting = {
     FLAG_DISABLED,
     FLAG_SECRET,
     FLAG_PRO,
+    FLAG_PUBLIC,
+    FLAG_PRIVATE,
     PREFERENCE_SETTINGS,
     ACCOUNT_SETTINGS,
     SETTINGS,

--- a/packages/hydrooj/src/model/setting.ts
+++ b/packages/hydrooj/src/model/setting.ts
@@ -262,7 +262,7 @@ AccountSetting(
     Setting('setting_info', 'bio', null, 'markdown', 'Bio'),
     Setting('setting_info', 'school', '', 'text', 'School', '', FLAG_PRIVATE),
     Setting('setting_info', 'studentId', '', 'text', 'Student ID', '', FLAG_PRIVATE),
-    Setting('setting_info', 'phone', null, 'text', 'Phone', null, FLAG_PRIVATE),
+    Setting('setting_info', 'phone', null, 'text', 'Phone', null, FLAG_DISABLED | FLAG_PRIVATE),
     Setting('setting_customize', 'backgroundImage',
         '/components/profile/backgrounds/1.jpg', 'text', 'Profile Background Image',
         'Choose the background image in your profile page.'),

--- a/packages/ui-default/templates/components/user.html
+++ b/packages/ui-default/templates/components/user.html
@@ -5,7 +5,7 @@
     <img class="small user-profile-avatar v-center" loading="lazy" src="{{ avatarUrl(udoc.avatar|default('')) }}" width="20" height="20">
   {% endif %}
   <a class="user-profile-name uname--lv{{ udoc.level|default(0) }}" href="{{ url('user_detail', uid=udoc._id) }}">
-    {% if handler.user.hasPerm(perm.PERM_VIEW_DISPLAYNAME) and udoc.displayName and udoc.displayName != udoc.uname %}
+    {% if handler.user.hasPerm(perm.PERM_VIEW_USER_PRIVATE_INFO) and udoc.displayName and udoc.displayName != udoc.uname %}
       {{ udoc.displayName }} ({{ udoc.uname }})
     {% else %}
       {{ udoc.uname }}

--- a/packages/ui-default/templates/training_detail.html
+++ b/packages/ui-default/templates/training_detail.html
@@ -18,12 +18,12 @@
         </li>
         <ul class="enroll_user_menu">
         {%- for uid, udoc in udict -%}
-        <li class="menu__item enroll_user_menu_item" data-uid="{{ uid }}" data-uname="{{ udoc.uname }}" {% if handler.user.hasPerm(perm.PERM_VIEW_DISPLAYNAME) and udoc.displayName %}data-displayname="{{ udoc.displayName }}"{% endif %}>
+        <li class="menu__item enroll_user_menu_item" data-uid="{{ uid }}" data-uname="{{ udoc.uname }}" {% if handler.user.hasPerm(perm.PERM_VIEW_USER_PRIVATE_INFO) and udoc.displayName %}data-displayname="{{ udoc.displayName }}"{% endif %}>
           <a href="./{{ tdoc._id }}?uid={{ uid }}" class="menu__link{% if (handler.request.query.uid or handler.user._id) == uid %} active{% endif %}">
             <span class="user-profile-link">
               <img class="small user-profile-avatar v-center" loading="lazy" src="{{ avatarUrl(udoc.avatar|default('')) }}" width="20" height="20">
               <span class="user-profile-name">
-                {% if handler.user.hasPerm(perm.PERM_VIEW_DISPLAYNAME) and udoc.displayName and udoc.displayName != udoc.uname %}
+                {% if handler.user.hasPerm(perm.PERM_VIEW_USER_PRIVATE_INFO) and udoc.displayName and udoc.displayName != udoc.uname %}
                   {{ udoc.displayName }} ({{ udoc.uname }})
                 {% else %}
                   {{ udoc.uname }}

--- a/packages/ui-default/templates/user_detail.html
+++ b/packages/ui-default/templates/user_detail.html
@@ -20,7 +20,7 @@
             <div class="media__body profile-header__main">
               <h1>
                 {{ udoc['uname'] }}
-                {% if handler.user.hasPerm(perm.PERM_VIEW_DISPLAYNAME) and udoc.displayName %}<small>({{ udoc['displayName'] }})</small>{% endif %}
+                {% if handler.user.hasPerm(perm.PERM_VIEW_USER_PRIVATE_INFO) and udoc.displayName %}<small>({{ udoc['displayName'] }})</small>{% endif %}
               </h1>
               <p>
                 {{ _('UID') }}: {{ udoc['_id'] }},


### PR DESCRIPTION
to replace #1055

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stronger privacy: display names and select profile fields (school, student ID, phone) are now private by default and shown only with permission.
  * Exports (HTML/CSV), scoreboards, training pages, and user views now honor the new private-info permission.

* **Refactor**
  * Unified permission handling and consistent inclusion/omission of private user fields across the app.

* **Documentation**
  * Updated localization text to reflect "user private info" wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->