### PR TITLE
core: fix tsdoc endAt error

### DIFF
--- a/packages/hydrooj/src/handler/contest.ts
+++ b/packages/hydrooj/src/handler/contest.ts
@@ -94,7 +94,8 @@ export class ContestDetailBaseHandler extends Handler {
             }
         }
         if (this.tdoc.duration && this.tsdoc?.startAt) {
-            this.tsdoc.endAt = moment(this.tsdoc.startAt).add(this.tdoc.duration, 'hours').toDate();
+            const endAt = moment(this.tsdoc.startAt).add(this.tdoc.duration, 'hours').toDate();
+            this.tsdoc.endAt = endAt < this.tdoc.endAt ? endAt : this.tdoc.endAt;
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Contest end time now consistently respects the originally scheduled end, even when recalculated from start time and duration.
  - Prevents contests from unintentionally extending beyond their configured end during schedule updates.
  - Ensures participant countdowns, visibility, and submission windows align with the intended contest timeframe.
  - Reduces confusion for organizers and participants by maintaining a stable end time across adjustments.
  - Improves reliability of contest scheduling displays and related time-based behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->