### PR TITLE
core&ui: assignment auto complete

### DIFF
--- a/packages/components/frontend/autocomplete/AutoComplete.tsx
+++ b/packages/components/frontend/autocomplete/AutoComplete.tsx
@@ -112,10 +112,16 @@ const AutoComplete = forwardRef(function Impl<T>(props: AutoCompleteProps<T>, re
       setCurrentItem(null);
       return;
     }
-    queryCache[query] ||= await queryItems(query);
-    for (const item of queryCache[query]) valueCache[itemKey(item)] = item;
-    setItemList(queryCache[query]);
-    setCurrentItem((!freeSolo && queryCache[query].length) ? 0 : null);
+    try {
+      queryCache[query] ||= await queryItems(query);
+      for (const item of queryCache[query]) valueCache[itemKey(item)] = item;
+      setItemList(queryCache[query]);
+      setCurrentItem((!freeSolo && queryCache[query].length) ? 0 : null);
+    } catch (e) {
+      console.error('Failed to query items', e);
+      setItemList([]);
+      setCurrentItem(null);
+    }
   };
 
   useEffect(() => {
@@ -135,6 +141,8 @@ const AutoComplete = forwardRef(function Impl<T>(props: AutoCompleteProps<T>, re
     Promise.resolve(props.fetchItems(ids)).then((items) => {
       for (const item of items) valueCache[itemKey(item)] = item;
       setRerender(!rerender);
+    }).catch((e) => {
+      console.error('Failed to fetch items', e);
     });
   }, [selectedKeys, multi]);
 
@@ -287,9 +295,13 @@ const AutoComplete = forwardRef(function Impl<T>(props: AutoCompleteProps<T>, re
               e.preventDefault();
               const ids = text.replace(/，/g, ',').split(',').filter((v) => v?.trim().length && !selectedKeys.includes(v));
               if (!ids.length) return;
-              const fetched = await props.fetchItems(ids);
-              for (const item of fetched) valueCache[itemKey(item)] = item;
-              setSelectedKeys([...selectedKeys, ...fetched.map((val) => itemKey(val))]);
+              try {
+                const fetched = await props.fetchItems(ids);
+                for (const item of fetched) valueCache[itemKey(item)] = item;
+                setSelectedKeys([...selectedKeys, ...fetched.map((val) => itemKey(val))]);
+              } catch (e) {
+                console.error('Failed to fetch items on paste', e);
+              }
             }}
             placeholder={props.placeholder}
             onBlur={() => setFocused(false)}

--- a/packages/components/frontend/autocomplete/AutoComplete.tsx
+++ b/packages/components/frontend/autocomplete/AutoComplete.tsx
@@ -299,8 +299,8 @@ const AutoComplete = forwardRef(function Impl<T>(props: AutoCompleteProps<T>, re
                 const fetched = await props.fetchItems(ids);
                 for (const item of fetched) valueCache[itemKey(item)] = item;
                 setSelectedKeys([...selectedKeys, ...fetched.map((val) => itemKey(val))]);
-              } catch (e) {
-                console.error('Failed to fetch items on paste', e);
+              } catch (err) {
+                console.error('Failed to fetch items on paste', err);
               }
             }}
             placeholder={props.placeholder}

--- a/packages/hydrooj/src/handler/domain.ts
+++ b/packages/hydrooj/src/handler/domain.ts
@@ -441,7 +441,6 @@ export const DomainApi = {
             domainId: Schema.string().required(),
         }),
         async (ctx, args) => {
-            if (args.domainId !== ctx.domain._id) throw new BadRequestError();
             if (!ctx.user.hasPerm(PERM.PERM_VIEW) && !ctx.user.hasPriv(PRIV.PRIV_VIEW_ALL_DOMAIN)) throw new PermissionError(PERM.PERM_VIEW);
             const groups = await user.listGroup(args.domainId);
             if (args.names?.length) {

--- a/packages/hydrooj/src/handler/domain.ts
+++ b/packages/hydrooj/src/handler/domain.ts
@@ -432,6 +432,24 @@ export const DomainApi = {
             return ddoc;
         },
     ),
+    groups: Query(
+        Schema.object({
+            search: Schema.string(),
+            names: Schema.array(Schema.string()),
+        }),
+        async (ctx, args) => {
+            const { domainId } = ctx.args;
+            const groups = await user.listGroup(domainId);
+            if (args.names?.length) {
+                return groups.filter((g) => args.names.includes(g.name));
+            }
+            if (args.search) {
+                const searchLower = args.search.toLowerCase();
+                return groups.filter((g) => g.name.toLowerCase().includes(searchLower));
+            }
+            return groups;
+        },
+    ),
     'domain.group': Mutation(
         Schema.object({
             name: Schema.string().required(),

--- a/packages/hydrooj/src/handler/domain.ts
+++ b/packages/hydrooj/src/handler/domain.ts
@@ -4,6 +4,7 @@ import moment from 'moment-timezone';
 import Schema from 'schemastery';
 import type { Context } from '../context';
 import {
+    BadRequestError,
     CannotDeleteSystemDomainError, DomainJoinAlreadyMemberError, DomainJoinForbiddenError, ForbiddenError,
     InvalidJoinInvitationCodeError, OnlyOwnerCanDeleteDomainError, PermissionError, RoleAlreadyExistError, ValidationError,
 } from '../error';
@@ -436,9 +437,10 @@ export const DomainApi = {
         Schema.object({
             search: Schema.string(),
             names: Schema.array(Schema.string()),
-            domainId: Schema.string(),
+            domainId: Schema.string().required(),
         }),
         async (ctx, args) => {
+            if (args.domainId !== ctx.domain._id) throw new BadRequestError();
             if (!ctx.user.hasPerm(PERM.PERM_VIEW) && !ctx.user.hasPriv(PRIV.PRIV_VIEW_ALL_DOMAIN)) throw new PermissionError(PERM.PERM_VIEW);
             const groups = await user.listGroup(args.domainId);
             if (args.names?.length) {

--- a/packages/hydrooj/src/handler/domain.ts
+++ b/packages/hydrooj/src/handler/domain.ts
@@ -439,6 +439,8 @@ export const DomainApi = {
         }),
         async (ctx, args) => {
             const { domainId } = ctx.args;
+            const udoc = await user.getById(domainId, ctx.user._id);
+            if (!udoc.hasPerm(PERM.PERM_VIEW) && !udoc.hasPriv(PRIV.PRIV_VIEW_ALL_DOMAIN)) throw new PermissionError(PERM.PERM_VIEW);
             const groups = await user.listGroup(domainId);
             if (args.names?.length) {
                 return groups.filter((g) => args.names.includes(g.name));

--- a/packages/hydrooj/src/handler/domain.ts
+++ b/packages/hydrooj/src/handler/domain.ts
@@ -436,12 +436,11 @@ export const DomainApi = {
         Schema.object({
             search: Schema.string(),
             names: Schema.array(Schema.string()),
+            domainId: Schema.string(),
         }),
         async (ctx, args) => {
-            const { domainId } = ctx.args;
-            const udoc = await user.getById(domainId, ctx.user._id);
-            if (!udoc.hasPerm(PERM.PERM_VIEW) && !udoc.hasPriv(PRIV.PRIV_VIEW_ALL_DOMAIN)) throw new PermissionError(PERM.PERM_VIEW);
-            const groups = await user.listGroup(domainId);
+            if (!ctx.user.hasPerm(PERM.PERM_VIEW) && !ctx.user.hasPriv(PRIV.PRIV_VIEW_ALL_DOMAIN)) throw new PermissionError(PERM.PERM_VIEW);
+            const groups = await user.listGroup(args.domainId);
             if (args.names?.length) {
                 return groups.filter((g) => args.names.includes(g.name));
             }

--- a/packages/hydrooj/src/handler/domain.ts
+++ b/packages/hydrooj/src/handler/domain.ts
@@ -4,7 +4,6 @@ import moment from 'moment-timezone';
 import Schema from 'schemastery';
 import type { Context } from '../context';
 import {
-    BadRequestError,
     CannotDeleteSystemDomainError, DomainJoinAlreadyMemberError, DomainJoinForbiddenError, ForbiddenError,
     InvalidJoinInvitationCodeError, NotFoundError, OnlyOwnerCanDeleteDomainError, PermissionError, RoleAlreadyExistError, ValidationError,
 } from '../error';

--- a/packages/ui-default/api.ts
+++ b/packages/ui-default/api.ts
@@ -24,13 +24,14 @@ export default load;
 export interface EventMap { }
 
 import AutoComplete from './components/autocomplete';
+import AssignSelectAutoComplete from './components/autocomplete/AssignSelectAutoComplete';
 import CustomSelectAutoComplete from './components/autocomplete/CustomSelectAutoComplete';
 import DomainSelectAutoComplete from './components/autocomplete/DomainSelectAutoComplete';
 import ProblemSelectAutoComplete from './components/autocomplete/ProblemSelectAutoComplete';
 import UserSelectAutoComplete from './components/autocomplete/UserSelectAutoComplete';
 
 export {
-  AutoComplete, CustomSelectAutoComplete, DomainSelectAutoComplete, ProblemSelectAutoComplete, UserSelectAutoComplete,
+  AssignSelectAutoComplete, AutoComplete, CustomSelectAutoComplete, DomainSelectAutoComplete, ProblemSelectAutoComplete, UserSelectAutoComplete,
 };
 export function addPage(page: import('./misc/Page').Page | (() => Promise<void> | void)) {
   window.Hydro.extraPages.push(page);

--- a/packages/ui-default/components/autocomplete/AssignSelectAutoComplete.tsx
+++ b/packages/ui-default/components/autocomplete/AssignSelectAutoComplete.tsx
@@ -1,0 +1,24 @@
+import AutoComplete, { AutoCompleteOptions } from '.';
+import AssignSelectAutoCompleteFC from './components/AssignSelectAutoComplete';
+
+export default class AssignSelectAutoComplete<Multi extends boolean> extends AutoComplete {
+  static DOMAttachKey = 'ucwAssignSelectAutoCompleteInstance';
+
+  constructor($dom, options: AutoCompleteOptions<Multi> = {}) {
+    super($dom, {
+      classes: 'assign-select',
+      component: AssignSelectAutoCompleteFC,
+      props: {
+        multi: true,
+        height: 'auto',
+      },
+      ...options,
+    });
+  }
+
+  value(): string {
+    return this.ref?.getSelectedItemKeys().join(',') ?? this.$dom.val();
+  }
+}
+
+window.Hydro.components.AssignSelectAutoComplete = AssignSelectAutoComplete;

--- a/packages/ui-default/components/autocomplete/components/AssignSelectAutoComplete.tsx
+++ b/packages/ui-default/components/autocomplete/components/AssignSelectAutoComplete.tsx
@@ -34,43 +34,33 @@ const AssignSelectAutoComplete = forwardRef<AutoCompleteHandle<AssignItem>, Auto
     ref={ref as any}
     cacheKey="assign"
     queryItems={async (query) => {
-      try {
-        const [users, groups] = await Promise.all([
-          api('users', { search: query }, ['_id', 'uname', 'displayName', 'avatarUrl']),
-          api('groups', { search: query }, ['name', 'uids']),
-        ]);
-        const userItems: AssignItem[] = users.map((user: Udoc) => toUserItem(user));
-        const groupItems: AssignItem[] = groups.map((group: GDoc) => toGroupItem(group));
-        return [...groupItems, ...userItems];
-      } catch (e) {
-        console.error('Failed to fetch assign items', e);
-        return [];
-      }
+      const [users, groups] = await Promise.all([
+        api('users', { search: query }, ['_id', 'uname', 'displayName', 'avatarUrl']),
+        api('groups', { search: query }, ['name', 'uids']),
+      ]);
+      const userItems: AssignItem[] = users.map((user: Udoc) => toUserItem(user));
+      const groupItems: AssignItem[] = groups.map((group: GDoc) => toGroupItem(group));
+      return [...groupItems, ...userItems];
     }}
     fetchItems={async (keys) => {
-      try {
-        const isUserId = (k: string) => /^-?[0-9]+$/.test(k);
-        const userIds: string[] = keys.filter((k) => isUserId(k));
-        const groupNames: string[] = keys.filter((k) => !isUserId(k));
+      const isUserId = (k: string) => /^-?[0-9]+$/.test(k);
+      const userIds = keys.filter((k) => isUserId(k));
+      const groupNames = keys.filter((k) => !isUserId(k));
 
-        const [users, groups]: [Udoc[], GDoc[]] = await Promise.all([
-          userIds.length > 0 ? api('users', { auto: userIds }, ['_id', 'uname', 'displayName']) : [],
-          groupNames.length > 0 ? api('groups', { names: groupNames }, ['name', 'uids']) : [],
-        ]);
+      const [users, groups]: [Udoc[], GDoc[]] = await Promise.all([
+        userIds.length > 0 ? api('users', { auto: userIds }, ['_id', 'uname', 'displayName']) : [],
+        groupNames.length > 0 ? api('groups', { names: groupNames }, ['name', 'uids']) : [],
+      ]);
 
-        const userItems: AssignItem[] = users.map((user: Udoc) => toUserItem(user));
-        const groupItems: AssignItem[] = keys
-          .filter((key) => !isUserId(key))
-          .map((key) => {
-            const group = groups.find((g) => g.name === key);
-            return group ? toGroupItem(group) : { type: 'group', key, name: key, invalid: true };
-          });
+      const userItems: AssignItem[] = users.map((user: Udoc) => toUserItem(user));
+      const groupItems: AssignItem[] = keys
+        .filter((key) => !isUserId(key))
+        .map((key) => {
+          const group = groups.find((g) => g.name === key);
+          return group ? toGroupItem(group) : { type: 'group', key, name: key, invalid: true };
+        });
 
-        return [...groupItems, ...userItems];
-      } catch (e) {
-        console.error('Failed to fetch assign items', e);
-        return [];
-      }
+      return [...groupItems, ...userItems];
     }}
     itemText={(item) => {
       if (item.type === 'group') {
@@ -82,17 +72,17 @@ const AssignSelectAutoComplete = forwardRef<AutoCompleteHandle<AssignItem>, Auto
     itemKey={(item) => item.key}
     renderItem={(item) => (
       <div className="media">
-        {item.type === 'user' ? (
+        {item.type === 'user' && (
           <div className="media__left medium">
             <img className="small user-profile-avatar" alt="" src={item.avatarUrl} width="30" height="30" />
           </div>
-        ) : null}
+        )}
         <div className="media__body medium">
           <div className="assign-select__name">
             {item.name}{item.type === 'user' && item.displayName && ` (${item.displayName})`}
           </div>
           <div className="assign-select__desc">
-            {item.type === 'group' ? <>Group • {item.uids?.length || 0} users</> : <>User • UID = {item.key}</>}
+            {item.type === 'group' ? `Group • ${item.uids?.length || 0} users` : `User • UID = ${item.key}`}
           </div>
         </div>
       </div>

--- a/packages/ui-default/components/autocomplete/components/AssignSelectAutoComplete.tsx
+++ b/packages/ui-default/components/autocomplete/components/AssignSelectAutoComplete.tsx
@@ -85,10 +85,9 @@ const AssignSelectAutoComplete = forwardRef<AutoCompleteHandle<AssignItem>, Auto
             <div className="media__body medium">
               <div className="assign-select__name">
                 {item.name}
-                {item.invalid && <span style={{ color: '#d93025' }}> (invalid)</span>}
               </div>
               <div className="assign-select__desc">
-                {item.invalid ? 'Group • Not found' : `Group • ${item.uids?.length || 0} users`}
+                Group • {item.uids?.length || 0} users
               </div>
             </div>
           </div>

--- a/packages/ui-default/components/autocomplete/components/AssignSelectAutoComplete.tsx
+++ b/packages/ui-default/components/autocomplete/components/AssignSelectAutoComplete.tsx
@@ -44,16 +44,8 @@ const AssignSelectAutoComplete = forwardRef<AutoCompleteHandle<AssignItem>, Auto
     }}
     fetchItems={async (keys) => {
       const isUserId = (k: string) => /^-?[0-9]+$/.test(k);
-      const userIds: string[] = [];
-      const groupNames: string[] = [];
-
-      keys.forEach((key) => {
-        if (isUserId(key)) {
-          userIds.push(key);
-        } else {
-          groupNames.push(key);
-        }
-      });
+      const userIds: string[] = keys.filter((k) => isUserId(k));
+      const groupNames: string[] = keys.filter((k) => !isUserId(k));
 
       const [users, groups]: [Udoc[], GDoc[]] = await Promise.all([
         userIds.length > 0 ? api('users', { auto: userIds }, ['_id', 'uname', 'displayName']) : [],
@@ -78,33 +70,23 @@ const AssignSelectAutoComplete = forwardRef<AutoCompleteHandle<AssignItem>, Auto
       return item.name + (item.displayName ? ` (${item.displayName})` : '');
     }}
     itemKey={(item) => item.key}
-    renderItem={(item) => {
-      if (item.type === 'group') {
-        return (
-          <div className="media">
-            <div className="media__body medium">
-              <div className="assign-select__name">
-                {item.name}
-              </div>
-              <div className="assign-select__desc">
-                Group • {item.uids?.length || 0} users
-              </div>
-            </div>
-          </div>
-        );
-      }
-      return (
-        <div className="media">
+    renderItem={(item) => (
+      <div className="media">
+        {item.type === 'user' ? (
           <div className="media__left medium">
             <img className="small user-profile-avatar" alt="" src={item.avatarUrl} width="30" height="30" />
           </div>
-          <div className="media__body medium">
-            <div className="assign-select__name">{item.name}{item.displayName && ` (${item.displayName})`}</div>
-            <div className="assign-select__desc">User • UID = {item.key}</div>
+        ) : null}
+        <div className="media__body medium">
+          <div className="assign-select__name">
+            {item.name}{item.type === 'user' && item.displayName && ` (${item.displayName})`}
+          </div>
+          <div className="assign-select__desc">
+            {item.type === 'group' ? <>Group • {item.uids?.length || 0} users</> : <>User • UID = {item.key}</>}
           </div>
         </div>
-      );
-    }}
+      </div>
+    )}
     {...{
       width: '100%',
       height: 'auto',

--- a/packages/ui-default/components/autocomplete/components/AssignSelectAutoComplete.tsx
+++ b/packages/ui-default/components/autocomplete/components/AssignSelectAutoComplete.tsx
@@ -34,13 +34,18 @@ const AssignSelectAutoComplete = forwardRef<AutoCompleteHandle<AssignItem>, Auto
     ref={ref as any}
     cacheKey="assign"
     queryItems={async (query) => {
-      const [users, groups] = await Promise.all([
-        api('users', { search: query }, ['_id', 'uname', 'displayName', 'avatarUrl']),
-        api('groups', { search: query }, ['name', 'uids']),
-      ]);
-      const userItems: AssignItem[] = users.map((user: Udoc) => toUserItem(user));
-      const groupItems: AssignItem[] = groups.map((group: GDoc) => toGroupItem(group));
-      return [...groupItems, ...userItems];
+      try {
+        const [users, groups] = await Promise.all([
+          api('users', { search: query }, ['_id', 'uname', 'displayName', 'avatarUrl']),
+          api('groups', { search: query }, ['name', 'uids']),
+        ]);
+        const userItems: AssignItem[] = users.map((user: Udoc) => toUserItem(user));
+        const groupItems: AssignItem[] = groups.map((group: GDoc) => toGroupItem(group));
+        return [...groupItems, ...userItems];
+      } catch (e) {
+        console.error('Failed to fetch assign items', e);
+        return [];
+      }
     }}
     fetchItems={async (keys) => {
       try {

--- a/packages/ui-default/pages/contest_edit.page.ts
+++ b/packages/ui-default/pages/contest_edit.page.ts
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import moment from 'moment';
+import AssignSelectAutoComplete from 'vj/components/autocomplete/AssignSelectAutoComplete';
 import LanguageSelectAutoComplete from 'vj/components/autocomplete/LanguageSelectAutoComplete';
 import ProblemSelectAutoComplete from 'vj/components/autocomplete/ProblemSelectAutoComplete';
 import UserSelectAutoComplete from 'vj/components/autocomplete/UserSelectAutoComplete';
@@ -11,6 +12,7 @@ const page = new NamedPage(['contest_edit', 'contest_create', 'homework_create',
   ProblemSelectAutoComplete.getOrConstruct($('[name="pids"]'), { multi: true, clearDefaultValue: false });
   UserSelectAutoComplete.getOrConstruct<true>($('[name="maintainer"]'), { multi: true, clearDefaultValue: false });
   LanguageSelectAutoComplete.getOrConstruct($('[name=langs]'), { multi: true });
+  AssignSelectAutoComplete.getOrConstruct($('[name="assign"]'), { multi: true });
   $('[name="rule"]').on('change', () => {
     const rule = $('[name="rule"]').val();
     $('.contest-rule-settings input').attr('disabled', 'disabled');


### PR DESCRIPTION
Add auto complete for group and users in contest/homework permission control.

<img width="907" height="336" alt="e8bdd2ce2fd9e45880b93fcd9ee98cb3" src="https://github.com/user-attachments/assets/36b3f0fb-540a-44cb-97c2-bbd3bbf9bf73" />

<img width="682" height="229" alt="image" src="https://github.com/user-attachments/assets/833fc8ac-39ea-432a-ac45-dfdd90023bf1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Public API to list domain groups with optional name or keyword filters.
  - Multi-select AssignSelectAutoComplete with avatars, names, and group metadata.
  - Assign selector added to the contest editor’s assign field for streamlined selection.

- Chores
  - Exposed AssignSelectAutoComplete via the shared UI API for reuse.

- Bug Fixes
  - Robust error handling in autocomplete fetching to avoid failures and keep UI state consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->