### PR TITLE
ui: 3 highlight fixes in dark mode

### DIFF
--- a/packages/ui-default/theme/dark.styl
+++ b/packages/ui-default/theme/dark.styl
@@ -406,5 +406,5 @@ $hover-background-color = #424242
   &.hasjs .collapsed #status:not([data-status="7"]) .compiler-text-mask
     background-image: linear-gradient(to bottom, transparent, #000000 25px)
 
-  .page--record_detail .subtask
+  &.page--record_detail .subtask
     background-color: #000 !important

--- a/packages/ui-default/theme/dark.styl
+++ b/packages/ui-default/theme/dark.styl
@@ -408,3 +408,6 @@ $hover-background-color = #424242
 
   &.page--record_detail .subtask
     background-color: #000 !important
+
+  &.page--contest_scoreboard .star-highlight 
+    background: #6f757b

--- a/packages/ui-default/theme/dark.styl
+++ b/packages/ui-default/theme/dark.styl
@@ -93,7 +93,7 @@ $hover-background-color = #424242
     box-shadow: 0 0.125rem 0.625rem rgba(255 255 255 20%)
 
   .section__table-header
-    background-color: rgba($table-header-bg-color, 0.95)
+    background-color: rgba(0, 0, 0, 0.95)
     box-shadow: 0 0.1875rem 0.125rem rgba(255 255 255 3%)
 
   .data-table tr


### PR DESCRIPTION
### 1. Ranking header opacity

In #1034 I have fixed it before. However CodeRabbit then gave me a wrong suggestion that misled me to perform the wrong fix in #1035 --- the macro `$table-header-bg-color` is not defined (or defined as `#fff`?). In this PR I fixed that.

### 2. Subtask bar highlight

I noticed that someone (#915 & #968) has attempted to fix this before, but the issue continues.

Their former Stylus code:

```stylus
  .page--record_detail .subtask // missing '&'
    background-color: #000 !important
```

turned into this CSS table:

```css
.theme--dark .page--record_detail .subtask { /* there is a space after '.theme--dark' */
    background-color: #000!important
}
```

however it should be (verified through practice):

```css
.theme--dark.page--record_detail .subtask { /* there is NOT a space after '.theme--dark' */
    background-color: #000!important
}
```

so a fix is required for the Stylus code:

```stylus
  &.page--record_detail .subtask // add a '&'
    background-color: #000 !important
```

### 3. Ranklist highlight

This is just a copy of #1037.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Dark theme: increased contrast for table headers to improve readability.
  * Contest scoreboard: added a star highlight background to make starred entries stand out.
  * Record detail view: subtle visual tweaks to subtask elements for improved consistency in dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->