### PR TITLE
core: add inspect helper & warning

### DIFF
--- a/packages/hydrooj/src/service/check.ts
+++ b/packages/hydrooj/src/service/check.ts
@@ -2,6 +2,7 @@
 
 import os from 'os';
 import { DisposableList } from 'cordis';
+import inspector from 'inspector';
 import { randomstring } from '@hydrooj/utils';
 import { Context, Service } from '../context';
 import * as system from '../model/system';
@@ -48,6 +49,10 @@ export default class CheckService extends Service {
             if (url === '/') warn("server.url isn't set.");
             const header = system.get('server.xff');
             if (header && !c.request.ip) warn('IP header seems incorrect.\nCheck dashboard>settings>server.');
+        });
+        this.addChecker('Inspector', async (c, log, warn) => {
+            const url = inspector.url();
+            if (url) warn(`Inspector is enabled at ${url}.`);
         });
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional, admin-only endpoint to generate memory heap snapshots, gated by a feature flag and access control. It validates the selected worker and returns snapshot details when executed on the current worker, otherwise responds with a status message.
  - System checks now display a warning when the runtime inspector is enabled, including its access URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->