### PR TITLE
package: (attempt to) correct dependency description

### DIFF
--- a/packages/hydrooj/package.json
+++ b/packages/hydrooj/package.json
@@ -8,7 +8,7 @@
     "author": "undefined <i@undefined.moe>",
     "license": "AGPL-3.0-or-later OR Proprietary",
     "engines": {
-        "node": ">=18"
+        "node": ">=22"
     },
     "preferUnplugged": true,
     "dependencies": {


### PR DESCRIPTION
Related: #1068

I beg your mercy if I mess up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Raised the minimum Node.js runtime requirement from v18 to v22. Users running self-hosted or local deployments must upgrade to Node.js 22+ to install, run, or update the app. Package managers may block installation on older runtimes. This aligns with current dependency and security baselines. No feature or behavior changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->