### PR TITLE
i18n: add missing i18n

### DIFF
--- a/packages/ui-default/locales/en.yaml
+++ b/packages/ui-default/locales/en.yaml
@@ -1,5 +1,6 @@
 __langname: English
 'File IO: {0}': 'File IO: {0}'
+'Tip: You are entering sudo mode.': 'Tip: You are entering <a href="https://docs.github.com/articles/sudo-mode">sudo mode</a>.'
 Can be Extended For: Extension
 Current Status: Status
 Handled Requests: Req

--- a/packages/ui-default/locales/zh.yaml
+++ b/packages/ui-default/locales/zh.yaml
@@ -687,7 +687,7 @@ Please attend contest to see the problems.: 请参加比赛来查看题目。
 Please claim the assignment to see the problems.: 认领作业后才可以查看作业内容。
 Please follow the instructions on your device to complete the verification.: 请按照您设备上的指示完成验证。
 Please select at least one file to perform this operation.: 请选择至少一个文件来执行此操作。
-Please select at least one problem to perform this operation.: 请至少选择一道题目以执行此操作。
+Please select at least one problem to perform this operation.: 请选择至少一道题目来执行此操作。
 Please select at least one role to perform this operation.: 请选择至少一个角色来进行操作。
 Please select at least one user to perform this operation.: 请选择至少一个用户来进行操作。
 Please set the balloon color for each problem first.: 请先为每道题设置气球颜色。

--- a/packages/ui-default/locales/zh.yaml
+++ b/packages/ui-default/locales/zh.yaml
@@ -951,6 +951,7 @@ The user is too lazy to leave something here...: 该用户太懒，这里啥也�
 Their account will not be deleted and they will be with the guest role until they re-join the domain.: 他们的账号不会被删除，并且之后将以 guest 角色访问，直到他们重新加入域。
 Theme: 主题
 There are no contests...: 没有比赛…
+There are no files currently.: 目前还没有文件。
 There is no homework so far ╰(*°▽°*)╯: 目前还没有作业 ╰(*°▽°*)╯
 This contest is not live.: 比赛没有开始。
 This email was sent by {0} automatically, and please do not reply directly.: 这封邮件由 {0} 自动发送，请勿直接回复。

--- a/packages/ui-default/locales/zh.yaml
+++ b/packages/ui-default/locales/zh.yaml
@@ -24,6 +24,7 @@ __langname: 简体中文
 '↓ Create Time': '↓ 创建时间'
 '↓ Update Time': '↓ 更新时间'
 'A domain ID cannot be changed after creation. It is supposed to be:': '创建后将无法更改 ID。ID 必须满足以下条件：'
+'After you''ve performed a sudo-protected action, you''ll only be asked to re-authenticate again after a few hours of inactivity.': '在您执行受保护的操作后，只有账户连续数小时不活动时，系统才会再次要求您重新验证身份。'
 'Copy "{data}" failed :(': '复制“{data}”失败 :('
 'Copy failed :(': '复制失败 :('
 'Current dataset: {0}': '当前测试数据: {0}'
@@ -47,6 +48,7 @@ __langname: 简体中文
 'Solved {0} problems, RP: {1} (No. {2})': '解决了 {0} 道题目，RP: {1} (No. {2})'
 'The domain owner:': 域所有者：
 'The value `{1}` of {0} already exists.': '{0} 的值 `{1}` 已经存在。'
+'Tip: You are entering {0}.': '提示：您正在进入 {0}。'  
 'Yes': 是
 "Effects only when Difficulty is not 'Use algorithm calculated'.": 仅当难度不为“使用算法计算”时才起效。
 "Split by ', '.": 由“, ”或“，”分隔。
@@ -188,6 +190,7 @@ Compilers' Version and Parameters: 编译器版本及参数
 Complete: 完成
 Completed: 已完成
 Config: 配置
+Confirm Access: 确认授权
 Confirm deleting the selected roles?: 您确定删除所选角色吗？
 Confirm deleting this comment? Its replies will be deleted as well.: 确认删除这个评论吗？回复会被同时删除。
 Confirm deleting this domain? This action cannot be undone.: '确认删除此域？此操作无法撤销。'
@@ -197,6 +200,7 @@ Confirm removing the selected users?: 您确定将所选用户移除吗？
 Confirm to delete the file?: 确认删除此文件吗？
 Confirm to delete the selected files?: 确认删除所选文件吗？
 Confirm to delete the selected problems?: 确认要删除所选题目吗？
+Confirm: 确认
 Confirmation mail has been sent to your new email.: 确认邮件已经发送到您的新电子邮箱。
 Congratulations! Your submission is accepted.: 恭喜！您的递交已评测通过。
 Contact Us: 联系我们
@@ -527,6 +531,7 @@ Legacy mode: 兼容模式
 Light: 亮色
 Limit user to finish contest within N hours: 限制用户在N小时内完成比赛
 Limitations: 限制
+Linked Accounts: 关联账户
 Links: 链接
 List View: 列表视图
 Live: 正在进行
@@ -558,6 +563,7 @@ Manage: 管理
 Manager: 管理
 Mark Green: 标绿
 Mark Red: 标红
+Mark user as joined using admin privilege: 使用管理员权限将用户标记为已加入
 Mark Yellow: 标黄
 Memory Cost: 内存占用
 Memory Info: 内存信息
@@ -905,6 +911,7 @@ Submit: 递交
 Submitted: 已递交
 Subtask {0}: 子任务 {0}
 Subtasks: 子任务
+sudo mode: Sudo 模式
 SuperUser: 超级管理员
 SuperUser's Password: 超级管理员的密码
 Support: 支持

--- a/packages/ui-default/locales/zh.yaml
+++ b/packages/ui-default/locales/zh.yaml
@@ -24,7 +24,6 @@ __langname: 简体中文
 '↓ Create Time': '↓ 创建时间'
 '↓ Update Time': '↓ 更新时间'
 'A domain ID cannot be changed after creation. It is supposed to be:': '创建后将无法更改 ID。ID 必须满足以下条件：'
-'After you''ve performed a sudo-protected action, you''ll only be asked to re-authenticate again after a few hours of inactivity.': '在您执行受保护的操作后，只有账户连续数小时不活动时，系统才会再次要求您重新验证身份。'
 'Copy "{data}" failed :(': '复制“{data}”失败 :('
 'Copy failed :(': '复制失败 :('
 'Current dataset: {0}': '当前测试数据: {0}'
@@ -48,8 +47,9 @@ __langname: 简体中文
 'Solved {0} problems, RP: {1} (No. {2})': '解决了 {0} 道题目，RP: {1} (No. {2})'
 'The domain owner:': 域所有者：
 'The value `{1}` of {0} already exists.': '{0} 的值 `{1}` 已经存在。'
-'Tip: You are entering {0}.': '提示：您正在进行 {0}。'  
+'Tip: You are entering sudo mode.': '提示：您正在进行<a href="https://docs.github.com/articles/sudo-mode">身份验证</a>。'
 'Yes': 是
+"After you've performed a sudo-protected action, you'll only be asked to re-authenticate again after a few hours of inactivity.": 在您执行受保护的操作后，只有账户连续数小时不活动时，系统才会再次要求您重新验证身份。
 "Effects only when Difficulty is not 'Use algorithm calculated'.": 仅当难度不为“使用算法计算”时才起效。
 "Split by ', '.": 由“, ”或“，”分隔。
 "View other's records": 查看他人的记录
@@ -911,7 +911,6 @@ Submit: 递交
 Submitted: 已递交
 Subtask {0}: 子任务 {0}
 Subtasks: 子任务
-sudo mode: 身份验证
 SuperUser: 超级管理员
 SuperUser's Password: 超级管理员的密码
 Support: 支持

--- a/packages/ui-default/locales/zh.yaml
+++ b/packages/ui-default/locales/zh.yaml
@@ -224,6 +224,7 @@ Contributions: 贡献
 Copy Email: 复制电子邮件
 Copy from: 复制自
 Copy Link: 复制链接
+Copy Problems: 复制题目
 Copy QQ Number: 复制QQ号
 Copy Selected: 复制选中
 Copy WeChat Account: 复制微信号

--- a/packages/ui-default/locales/zh.yaml
+++ b/packages/ui-default/locales/zh.yaml
@@ -48,7 +48,7 @@ __langname: 简体中文
 'Solved {0} problems, RP: {1} (No. {2})': '解决了 {0} 道题目，RP: {1} (No. {2})'
 'The domain owner:': 域所有者：
 'The value `{1}` of {0} already exists.': '{0} 的值 `{1}` 已经存在。'
-'Tip: You are entering {0}.': '提示：您正在进入 {0}。'  
+'Tip: You are entering {0}.': '提示：您正在进行 {0}。'  
 'Yes': 是
 "Effects only when Difficulty is not 'Use algorithm calculated'.": 仅当难度不为“使用算法计算”时才起效。
 "Split by ', '.": 由“, ”或“，”分隔。
@@ -911,7 +911,7 @@ Submit: 递交
 Submitted: 已递交
 Subtask {0}: 子任务 {0}
 Subtasks: 子任务
-sudo mode: Sudo 模式
+sudo mode: 身份验证
 SuperUser: 超级管理员
 SuperUser's Password: 超级管理员的密码
 Support: 支持

--- a/packages/ui-default/locales/zh.yaml
+++ b/packages/ui-default/locales/zh.yaml
@@ -341,6 +341,7 @@ Download All: 下载全部
 Download Dataset: 下载数据集
 Download Selected: 下载选中
 Download: 下载
+Downloading...: 下载中...
 Downvote: 差评
 Duration (hours): 持续时间 (小时)
 Duration: 持续时间
@@ -686,6 +687,7 @@ Please attend contest to see the problems.: 请参加比赛来查看题目。
 Please claim the assignment to see the problems.: 认领作业后才可以查看作业内容。
 Please follow the instructions on your device to complete the verification.: 请按照您设备上的指示完成验证。
 Please select at least one file to perform this operation.: 请选择至少一个文件来执行此操作。
+Please select at least one problem to perform this operation.: 请至少选择一道题目以执行此操作。
 Please select at least one role to perform this operation.: 请选择至少一个角色来进行操作。
 Please select at least one user to perform this operation.: 请选择至少一个用户来进行操作。
 Please set the balloon color for each problem first.: 请先为每道题设置气球颜色。
@@ -842,6 +844,8 @@ Selected categories: 已选标签
 Selected files have been deleted.: 所选文件已被删除。
 Selected files have been renamed.: 所选文件已被重命名。
 Selected problems have been deleted.: 所选题目已被删除。
+Selected problems have been hided.: 所选题目已被隐藏。
+Selected problems have been unhided.: 所选题目已取消隐藏。
 Selected roles have been deleted.: 所选角色已删除。
 Selected users have been removed from the domain.: 所选用户已从此域中移除。
 Send By: 递送者

--- a/packages/ui-default/locales/zh.yaml
+++ b/packages/ui-default/locales/zh.yaml
@@ -224,6 +224,7 @@ Contributions: 贡献
 Copy Email: 复制电子邮件
 Copy from: 复制自
 Copy Link: 复制链接
+Copy Problem: 复制题目
 Copy Problems: 复制题目
 Copy QQ Number: 复制QQ号
 Copy Selected: 复制选中

--- a/packages/ui-default/locales/zh.yaml
+++ b/packages/ui-default/locales/zh.yaml
@@ -824,6 +824,8 @@ Scoreboard (Hidden): 成绩表 (隐藏)
 Scoreboard: 成绩表
 Scoring method: 评分方式
 Scripts: 脚本
+Search contests...: 搜索比赛...
+Search homeworks...: 搜索作业...
 Search: 搜索
 Secret (visible to admins): 保密（对管理员可见）
 Secret: 保密
@@ -834,6 +836,7 @@ Select a role: 选择一个角色
 Select All: 全选
 Select Category: 选择标签
 Select None: 全不选
+Select Problems: 选择题目
 Select User: 选择用户
 Selected categories: 已选标签
 Selected files have been deleted.: 所选文件已被删除。

--- a/packages/ui-default/pages/domain_user.page.js
+++ b/packages/ui-default/pages/domain_user.page.js
@@ -23,12 +23,12 @@ const page = new NamedPage('domain_user', () => {
   });
 
   async function handleClickAddUser() {
-    const res = await prompt('Add User', {
+    const res = await prompt(i18n('Add User'), {
       user: {
         type: 'userId',
         required: true,
         autofocus: true,
-        label: 'Username / UID',
+        label: i18n('Username / UID'),
         columns: 6,
       },
       role: {
@@ -41,7 +41,7 @@ const page = new NamedPage('domain_user', () => {
       ...(UiContext.canForceJoin ? {
         join: {
           type: 'checkbox',
-          label: 'Mark user as joined using admin privilege',
+          label: i18n('Mark user as joined using admin privilege'),
         },
       } : {}),
     });

--- a/packages/ui-default/pages/problem_main.page.tsx
+++ b/packages/ui-default/pages/problem_main.page.tsx
@@ -382,7 +382,7 @@ function ProblemSelectionDisplay(props) { // eslint-disable-line
         <div className="dialog__body" style={{ height: 'calc(100% - 45px)' }}>
           <div className="row">
             <div className="columns">
-              <h1>Select Problems</h1>
+              <h1>{i18n('Select Problems')}</h1>
             </div>
           </div>
           <div className="row">

--- a/packages/ui-default/templates/user_sudo.html
+++ b/packages/ui-default/templates/user_sudo.html
@@ -32,7 +32,7 @@
     </form>
     <div class="row"><div class="columns">
       <div class="text-center supplementary inverse typo">
-        <p>{{ _('Tip: You are entering {0}.').format('<a href="https://docs.github.com/articles/sudo-mode">' + _('sudo mode') + '</a>')|safe }}</p>
+        <p>{{ _('Tip: You are entering sudo mode.')|safe }}</p>
         <p>{{ _("After you've performed a sudo-protected action, you'll only be asked to re-authenticate again after a few hours of inactivity.") }}</p>
       </div>
     </div></div>

--- a/packages/ui-default/templates/user_sudo.html
+++ b/packages/ui-default/templates/user_sudo.html
@@ -31,9 +31,9 @@
       </div></div>
     </form>
     <div class="row"><div class="columns">
-      <div class="text-center supplementary inverse">
-        <p><strong>Tip:</strong> You are entering <a href="https://docs.github.com/articles/sudo-mode">sudo mode</a>.</p>
-        <p>After you've performed a sudo-protected action, you'll only be asked to re-authenticate again after a few hours of inactivity.</p>
+      <div class="text-center supplementary inverse typo">
+        <p>{{ _('Tip: You are entering {0}.').format('<a href="https://docs.github.com/articles/sudo-mode">' + _('sudo mode') + '</a>')|safe }}</p>
+        <p>{{ _("After you've performed a sudo-protected action, you'll only be asked to re-authenticate again after a few hours of inactivity.") }}</p>
       </div>
     </div></div>
     {% if UserContext.authn or UserContext.tfa %}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI prompts, tip blocks and labels for adding users and sudo-mode flows are now localized and render as translated messages.

* **Localization**
  * Added Chinese and English localized strings for sudo tips (with preserved link text), re-authentication messaging, confirm/authorization labels, copy-related actions, linked-account texts, search placeholders, selection actions, and admin user-management messages; minor translation alignment and consistency fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->