### PR TITLE
core: 3+1 discussion module bug fixes

### DIFF
--- a/packages/hydrooj/src/handler/discussion.ts
+++ b/packages/hydrooj/src/handler/discussion.ts
@@ -56,7 +56,7 @@ class DiscussionHandler extends Handler {
         // TODO(twd2): exclude problem/contest discussions?
         // TODO(iceboy): continuation based pagination.
         this.vnode = await discussion.getVnode(domainId, typeMapper[type], name, this.user._id);
-        if (!discussion.checkVNodeVisibility(typeMapper[type], this.vnode, this.user)) throw new DiscussionNodeNotFoundError(this.vnode.id);
+        if (!discussion.checkVNodeVisibility(typeMapper[type], this.vnode, this.user)) throw new DiscussionNodeNotFoundError(domainId, this.vnode.id);
         if (this.ddoc) {
             this.ddoc.parentType ||= this.vnode.type;
             this.ddoc.parentId ||= this.vnode.id;

--- a/packages/hydrooj/src/handler/discussion.ts
+++ b/packages/hydrooj/src/handler/discussion.ts
@@ -55,11 +55,15 @@ class DiscussionHandler extends Handler {
         }
         // TODO(twd2): exclude problem/contest discussions?
         // TODO(iceboy): continuation based pagination.
-        this.vnode = await discussion.getVnode(domainId, typeMapper[type], name, this.user._id);
-        if (!discussion.checkVNodeVisibility(typeMapper[type], this.vnode, this.user)) throw new DiscussionNodeNotFoundError(domainId, this.vnode.id);
-        if (this.ddoc) {
-            this.ddoc.parentType ||= this.vnode.type;
-            this.ddoc.parentId ||= this.vnode.id;
+        if (typeMapper[type] !== undefined && name !== undefined) {
+            this.vnode = await discussion.getVnode(domainId, typeMapper[type], name, this.user._id);
+            if (!discussion.checkVNodeVisibility(typeMapper[type], this.vnode, this.user)) {
+                throw new DiscussionNodeNotFoundError(domainId, this.vnode.id);
+            }
+            if (this.ddoc) {
+                this.ddoc.parentType ||= this.vnode.type;
+                this.ddoc.parentId ||= this.vnode.id;
+            }
         }
     }
 }

--- a/packages/hydrooj/src/handler/discussion.ts
+++ b/packages/hydrooj/src/handler/discussion.ts
@@ -55,20 +55,18 @@ class DiscussionHandler extends Handler {
         }
         // TODO(twd2): exclude problem/contest discussions?
         // TODO(iceboy): continuation based pagination.
-        if (typeMapper[type] !== undefined && name !== undefined) {
-            this.vnode = await discussion.getVnode(domainId, typeMapper[type], name, this.user._id);
-            if (!discussion.checkVNodeVisibility(typeMapper[type], this.vnode, this.user)) {
-                throw new DiscussionNodeNotFoundError(domainId, this.vnode.id);
-            }
-            if (this.ddoc) {
-                this.ddoc.parentType ||= this.vnode.type;
-                this.ddoc.parentId ||= this.vnode.id;
-            }
+        this.vnode = await discussion.getVnode(domainId, typeMapper[type], name, this.user._id);
+        if (!discussion.checkVNodeVisibility(typeMapper[type], this.vnode, this.user)) {
+            throw new DiscussionNodeNotFoundError(domainId, this.vnode.id);
+        }
+        if (this.ddoc) {
+            this.ddoc.parentType ||= this.vnode.type;
+            this.ddoc.parentId ||= this.vnode.id;
         }
     }
 }
 
-class DiscussionMainHandler extends DiscussionHandler {
+class DiscussionMainHandler extends Handler {
     @param('page', Types.PositiveInt, true)
     @param('all', Types.Boolean)
     async get(domainId: string, page = 1, all = false) {
@@ -426,7 +424,7 @@ class DiscussionEditHandler extends DiscussionHandler {
 }
 
 export async function apply(ctx) {
-    ctx.Route('discussion_main', '/discuss', DiscussionMainHandler);
+    ctx.Route('discussion_main', '/discuss', DiscussionMainHandler, PERM.PERM_VIEW_DISCUSSION);
     ctx.Route('discussion_detail', '/discuss/:did', DiscussionDetailHandler);
     ctx.Route('discussion_edit', '/discuss/:did/edit', DiscussionEditHandler);
     ctx.Route('discussion_raw', '/discuss/:did/raw', DiscussionRawHandler);

--- a/packages/hydrooj/src/handler/discussion.ts
+++ b/packages/hydrooj/src/handler/discussion.ts
@@ -64,7 +64,7 @@ class DiscussionHandler extends Handler {
     }
 }
 
-class DiscussionMainHandler extends Handler {
+class DiscussionMainHandler extends DiscussionHandler {
     @param('page', Types.PositiveInt, true)
     @param('all', Types.Boolean)
     async get(domainId: string, page = 1, all = false) {

--- a/packages/hydrooj/src/model/discussion.ts
+++ b/packages/hydrooj/src/model/discussion.ts
@@ -293,11 +293,12 @@ export async function getVnode(domainId: string, type: number, id: string, uid?:
             ...tdoc, type, id: _id, hidden: false,
         };
     }
-    const resultNodeId = await getNode(domainId, id);
-    if (id !== undefined && resultNodeId === null) throw new DiscussionNodeNotFoundError(domainId, `node/${id}`);
+    const hasId = id !== undefined;
+    const resultNode = hasId ? await getNode(domainId, id) : null;
+    if (hasId && !resultNode) throw new DiscussionNodeNotFoundError(domainId, `node/${id}`);
     return {
         title: id,
-        ...resultNodeId,
+        ...(resultNode ?? {}),
         type,
         id,
         owner: 1,

--- a/packages/hydrooj/src/model/discussion.ts
+++ b/packages/hydrooj/src/model/discussion.ts
@@ -293,9 +293,11 @@ export async function getVnode(domainId: string, type: number, id: string, uid?:
             ...tdoc, type, id: _id, hidden: false,
         };
     }
+    const resultNodeId = await getNode(domainId, id);
+    if (id !== undefined && resultNodeId === null) throw new DiscussionNodeNotFoundError(domainId, `node/${id}`);
     return {
         title: id,
-        ...await getNode(domainId, id),
+        ...resultNodeId,
         type,
         id,
         owner: 1,

--- a/packages/hydrooj/src/model/discussion.ts
+++ b/packages/hydrooj/src/model/discussion.ts
@@ -276,15 +276,15 @@ export function flushNodes(domainId: string) {
 export async function getVnode(domainId: string, type: number, id: string, uid?: number) {
     if (type === document.TYPE_PROBLEM) {
         const pdoc = await problem.get(domainId, Number.isSafeInteger(+id) ? +id : id, problem.PROJECTION_LIST);
-        if (!pdoc) throw new DiscussionNodeNotFoundError(`problem/${id}`);
+        if (!pdoc) throw new DiscussionNodeNotFoundError(domainId, `problem/${id}`);
         return { ...pdoc, type, id: pdoc.docId };
     }
     if ([document.TYPE_CONTEST, document.TYPE_TRAINING].includes(type as any)) {
         const model = type === document.TYPE_TRAINING ? training : contest;
-        if (!ObjectId.isValid(id)) throw new DiscussionNodeNotFoundError(`contest/${id}`);
+        if (!ObjectId.isValid(id)) throw new DiscussionNodeNotFoundError(domainId, `contest/${id}`);
         const _id = new ObjectId(id);
         const tdoc = await model.get(domainId, _id);
-        if (!tdoc) throw new DiscussionNodeNotFoundError(`contest/${id}`);
+        if (!tdoc) throw new DiscussionNodeNotFoundError(domainId, `contest/${id}`);
         if (uid) {
             const tsdoc = await model.getStatus(domainId, _id, uid);
             tdoc.attend = tsdoc?.attend || tsdoc?.enroll;

--- a/packages/hydrooj/src/model/discussion.ts
+++ b/packages/hydrooj/src/model/discussion.ts
@@ -281,10 +281,11 @@ export async function getVnode(domainId: string, type: number, id: string, uid?:
     }
     if ([document.TYPE_CONTEST, document.TYPE_TRAINING].includes(type as any)) {
         const model = type === document.TYPE_TRAINING ? training : contest;
-        if (!ObjectId.isValid(id)) throw new DiscussionNodeNotFoundError(domainId, `contest/${id}`);
+        const typeName = type === document.TYPE_TRAINING ? 'training' : 'contest';
+        if (!ObjectId.isValid(id)) throw new DiscussionNodeNotFoundError(domainId, `${typeName}/${id}`);
         const _id = new ObjectId(id);
         const tdoc = await model.get(domainId, _id);
-        if (!tdoc) throw new DiscussionNodeNotFoundError(domainId, `contest/${id}`);
+        if (!tdoc) throw new DiscussionNodeNotFoundError(domainId, `${typeName}/${id}`);
         if (uid) {
             const tsdoc = await model.getStatus(domainId, _id, uid);
             tdoc.attend = tsdoc?.attend || tsdoc?.enroll;

--- a/packages/hydrooj/src/model/discussion.ts
+++ b/packages/hydrooj/src/model/discussion.ts
@@ -294,12 +294,9 @@ export async function getVnode(domainId: string, type: number, id: string, uid?:
             ...tdoc, type, id: _id, hidden: false,
         };
     }
-    const hasId = id !== undefined;
-    const resultNode = hasId ? await getNode(domainId, id) : null;
-    if (hasId && !resultNode) throw new DiscussionNodeNotFoundError(domainId, `node/${id}`);
     return {
         title: id,
-        ...(resultNode ?? {}),
+        ...await getNode(domainId, id),
         type,
         id,
         owner: 1,


### PR DESCRIPTION
### 1. `DiscussionMainHandler` ought to extend `DiscussionHandler`, not `Handler` (Commit b9b28a6)

All handlers expect `DiscussionMainHandler` extend `DiscussionHandler` instead of `Handler`. This exception causes a bug that, the `PERM.PERM_VIEW_DISCUSSION` permission is not required while trying to enter the `/discuss` route. Someone says I should simply add a `this.checkPerm(PERM.PERM_VIEW_DISCUSSION);` for `DiscussionMainHandler` but that seems to break the consistency.

### 2. Fix missing `domainId` for `DiscussionNodeNotFoundError` (Commit 144e92a, 98aaefb)

In `packages/src/error.ts` the `DiscussionNodeNotFoundError` hint text is defined as `Discussion node {1} not found.`, in which the node ID is the second argument, not the first. Compared with the `DiscussionNotFoundError` and other calls in the context, I believe the missing first argument should be `domainId`.

### 3. Add node existence check for conventional discussion nodes like `node/nodeId` (Commit 8bb3f8f)

I guess the reason why this check has not applied before is that, while trying to enter the `/discuss` route, the value `undefined` is given as the node ID. However, besides that special case, node existence check is required.

---------

### 4. Split `DiscussionNodeNotFoundError` tracing for `contest/id` and `training/id` (Commit bccc3a6 by CodeRabbit)

(Just copying CodeRabbit's suggestions, no more information)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * "Node not found" errors now include domain context for clearer diagnostics.
  * Stricter validation of discussion references (problem/contest/training) to reduce false misses.
  * Parent linkage preserved when discussion configuration exists, preventing lost relationships.
  * Main discussion view now requires appropriate viewing permission to access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->