### PR TITLE
Unify authentication error messages to prevent username enumeration

### DIFF
--- a/packages/hydrooj/locales/zh.yaml
+++ b/packages/hydrooj/locales/zh.yaml
@@ -425,6 +425,7 @@ Instead of copying the test data directly, the test data of the copied problems 
 Introduce must not exceed 500 characters and it will be shown in the list view.: 简介不能超过 500 个字符，将显示在列表页面中。
 Introduce: 简介
 Invalid password for user {0}.: 用户 {0} 的密码错误。
+Invalid username or password.: 用户名或密码错误。
 Invalid: 无效
 Invitation Code: 邀请码
 IO: 输入输出

--- a/packages/hydrooj/src/error.ts
+++ b/packages/hydrooj/src/error.ts
@@ -12,7 +12,7 @@ export const SendMailError = Err('SendMailError', UserFacingError, 'Failed to se
 
 export const AlreadyVotedError = Err('AlreadyVotedError', ForbiddenError, "You've already voted.");
 export const BuiltinLoginError = Err('BuiltinLoginError', ForbiddenError, 'Builtin login is disabled.');
-export const LoginError = Err('LoginError', ForbiddenError, 'Invalid password for user {0}.');
+export const LoginError = Err('LoginError', ForbiddenError, 'Invalid username or password.');
 export const AccessDeniedError = Err('AccessDeniedError', ForbiddenError, 'Access denied.');
 export const UserAlreadyExistError = Err('UserAlreadyExistError', ForbiddenError, 'User {0} already exists.');
 export const InvalidTokenError = Err('InvalidTokenError', ForbiddenError, 'The {0} Token is invalid.');
@@ -67,7 +67,7 @@ export const ProblemConfigError = Err('ProblemConfigError', BadRequestError, 'In
 export const ProblemIsReferencedError = Err('ProblemIsReferencedError', BadRequestError, 'Cannot {0} of a referenced problem.');
 export const AuthOperationError = Err('AuthOperationError', BadRequestError, '{0} is already {1}.');
 
-export const UserNotFoundError = Err('UserNotFoundError', NotFoundError, 'User {0} not found.');
+export const UserNotFoundError = Err('LoginError', NotFoundError, 'Invalid username or password.');
 export const NoProblemError = Err('NoProblemError', NotFoundError, 'No problem.');
 export const RecordNotFoundError = Err('RecordNotFoundError', NotFoundError, 'Record {0} not found.');
 export const ProblemDataNotFoundError = Err('ProblemDataNotFoundError', NotFoundError, 'Data of problem {0} not found.');

--- a/packages/hydrooj/src/error.ts
+++ b/packages/hydrooj/src/error.ts
@@ -67,7 +67,7 @@ export const ProblemConfigError = Err('ProblemConfigError', BadRequestError, 'In
 export const ProblemIsReferencedError = Err('ProblemIsReferencedError', BadRequestError, 'Cannot {0} of a referenced problem.');
 export const AuthOperationError = Err('AuthOperationError', BadRequestError, '{0} is already {1}.');
 
-export const UserNotFoundError = Err('LoginError', NotFoundError, 'Invalid username or password.');
+export const UserNotFoundError = Err('LoginError', ForbiddenError, 'Invalid username or password.');
 export const NoProblemError = Err('NoProblemError', NotFoundError, 'No problem.');
 export const RecordNotFoundError = Err('RecordNotFoundError', NotFoundError, 'Record {0} not found.');
 export const ProblemDataNotFoundError = Err('ProblemDataNotFoundError', NotFoundError, 'Data of problem {0} not found.');


### PR DESCRIPTION
packages/hydrooj/src/error.ts:

用户名以及密码错误均使用“用户名或密码错误”，防止用户名被枚举+密码爆破导致后台被控制。

---

packages/hydrooj/locales/zh.yaml:

增加翻译：
Invalid username or password.: 用户名或密码错误。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication error messages for login failures are now consistent and generic across scenarios.
* **Localization**
  * Added Chinese translation for the generic login failure message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->