### PR TITLE
ui: allow autocomplete dropdown to overflow

### DIFF
--- a/packages/ui-default/components/problemconfig/index.tsx
+++ b/packages/ui-default/components/problemconfig/index.tsx
@@ -48,7 +48,9 @@ export default function ProblemConfig(props: Props) {
 
   return <ContextMenuProvider>
     <div ref={setContainer}>
-      <Allotment defaultSizes={[2, 3]}>
+      <Allotment
+        defaultSizes={[2, 3]}
+        className="problem-config-allotment">
         <Allotment.Pane>
           <div style={{ height: '100%', overflow: 'auto' }}>
             <ProblemConfigEditor ref={setEditor} />

--- a/packages/ui-default/pages/problem_config.page.styl
+++ b/packages/ui-default/pages/problem_config.page.styl
@@ -9,6 +9,12 @@
   input::placeholder
     color: rgba(95,107,124,.6)!important
 
+  .problem-config-allotment  
+    overflow: visible !important  
+      
+    .split-view-container > .split-view-view  
+      overflow: visible !important
+
   .problem-config-form
     font-family: var(--code-font-family)
   


### PR DESCRIPTION
perhaps there's a better way to fix this (?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted overflow visibility settings for problem configuration layout sections to ensure content displays properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->