### PR TITLE
backup: optimize backup order

### DIFF
--- a/packages/hydrooj/src/commands/db.ts
+++ b/packages/hydrooj/src/commands/db.ts
@@ -76,13 +76,13 @@ export function register(cli: CAC) {
                     exec('zip', ['-r', target, item], { cwd, stdio: 'inherit' });
                     if (!keepSource) fs.removeSync(path.join(cwd, item));
                 };
-            addFile(dir, 'dump', false);
-            if (!argv.options.dbOnly) addFile('/data', 'file');
             if (argv.options.withAddons) {
                 if (fs.existsSync(path.join(hydroPath, 'addons'))) addFile(hydroPath, 'addons');
                 if (fs.existsSync(path.join(hydroPath, 'addon.json'))) addFile(hydroPath, 'addon.json');
             }
             if (argv.options.withLogs && fs.existsSync('/data/access.log')) addFile('/data', 'access.log');
+            addFile(dir, 'dump', false);
+            if (!argv.options.dbOnly) addFile('/data', 'file');
             if (argv.options.r) {
                 await withPasswordFile(argv.options.p, async (file) => {
                     exec('restic', ['backup', '-r', argv.options.r.toString(), '-p', file, ...filesToAdd], { stdio: 'inherit', cwd: '/data' });


### PR DESCRIPTION
Current the files are zipped in the following order:

1. `/data/db/hydro` (I/O with 1)
2. `/data/file/hydro` (I/O with 1, 2)
3. `/root/.hydro/addon` (I/O with 1, 2, 3)
4. `/data/access.log` (I/O with 1, 2, 3, 4)

However `/data/file/hydro` (all testdata) could be huge and this order made up to 6 copies of that.

So a somewhat more appropriate order might be:

1. `/root/.hydro/addon.json`
2. `/data/access.log`
3. `/data/db`
4. `/data/file/hydro`

In practice (details are listed below) this modification did make the process ~10% faster.

```plain
Data size:
  /data/db/hydro: 57,118,962 bytes
  /data/file/hydro: 9,092,414,742 bytes
  /root/.hydro/addon: 527 bytes
  /data/access.log: 865,547,422 bytes
Command:
  hydrooj backup --withAddons --withLogs
Time:
  11:37:43 - 11:56:43 (before, 19m 0s)
  12:00:49 - 12:17:18 (after, 17m 9s)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reordered internal backup operations sequence within database backup flow for improved organization.

**Note:** This is an internal code reorganization with no user-visible functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->