### PR TITLE
ui: render long katex in frontend

### DIFF
--- a/packages/ui-default/backendlib/markdown-it-katex.ts
+++ b/packages/ui-default/backendlib/markdown-it-katex.ts
@@ -122,12 +122,12 @@ export default function plugin(md) {
     }
   };
   const inlineRenderer = function (tokens, idx) {
-    if (tokens[idx].content.length > limit) return `$${tokens[idx].content.trim()}$`;
+    if (tokens[idx].content.length > limit) return `$${escapeHtml(tokens[idx].content.trim())}$`;
     return render(tokens[idx].content);
   };
 
   const blockRenderer = function (tokens, idx) {
-    if (tokens[idx].content.length > limit) return `$$${tokens[idx].content.trim()}$$`;
+    if (tokens[idx].content.length > limit) return `$$${escapeHtml(tokens[idx].content.trim())}$$`;
     return `${render(tokens[idx].content, true)}\n`;
   };
   md.inline.ruler.after('escape', 'math_inline', inline);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTML escaping for long mathematical expressions in both inline and block math rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->