### PR TITLE
*: fix capitalization of the letter H in GitHub

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -45,6 +45,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 In dictionary order:
 
-- [Github](https://github.com/) Code hosting and workflow.  
+- [GitHub](https://github.com/) Code hosting and workflow.  
 - [criyle](https://github.com/criyle) Sandbox.  
 - [Vijos](https://github.com/vijos/vj4) UI framework.  

--- a/README.md
+++ b/README.md
@@ -1002,7 +1002,7 @@ Hydro 用户群：1085853538
 
 排名不分先后，按照链接字典序  
 
-- [Github](https://github.com/) 为 Hydro 提供了代码托管与自动构建。  
+- [GitHub](https://github.com/) 为 Hydro 提供了代码托管与自动构建。  
 - [criyle](https://github.com/criyle) 提供评测沙箱实现。  
 - [Vijos](https://github.com/vijos/vj4) 为 Hydro 提供了 UI 框架。  
 

--- a/packages/hydrooj/README.md
+++ b/packages/hydrooj/README.md
@@ -2,4 +2,4 @@
 
 Copyright [@hydro-dev](https://github.com/hydro-dev) team.
 
-Other information please refer to [Github repository](https://github.com/hydro-dev/Hydro) and [Official document](https://hydro.js.org) .
+Other information please refer to [GitHub repository](https://github.com/hydro-dev/Hydro) and [Official document](https://hydro.js.org) .

--- a/packages/hydrooj/locales/ko.yaml
+++ b/packages/hydrooj/locales/ko.yaml
@@ -391,7 +391,7 @@ Login to Attend Contest: 대회에 참가하려면 로그인하십시오
 Login to Claim Homework: 과제를 받으려면 로그인하십시오
 Login to Create a Discussion: 토론을 만드려면 로그인하십시오
 Login to Submit: 제출하려면 로그인하십시오
-Login with Github: Login with Github
+Login with GitHub: Login with GitHub
 Login with Google: Login with Google
 Login: 로그인
 Logout All Sessions: 모든 세션에서 로그아웃

--- a/packages/hydrooj/locales/ko.yaml
+++ b/packages/hydrooj/locales/ko.yaml
@@ -391,8 +391,6 @@ Login to Attend Contest: 대회에 참가하려면 로그인하십시오
 Login to Claim Homework: 과제를 받으려면 로그인하십시오
 Login to Create a Discussion: 토론을 만드려면 로그인하십시오
 Login to Submit: 제출하려면 로그인하십시오
-Login with GitHub: Login with GitHub
-Login with Google: Login with Google
 Login: 로그인
 Logout All Sessions: 모든 세션에서 로그아웃
 Logout This Session: 이 세션에서 로그아웃

--- a/packages/login-with-github/README.md
+++ b/packages/login-with-github/README.md
@@ -1,1 +1,1 @@
-# Login-With-Github
+# Login-With-GitHub

--- a/packages/login-with-github/index.ts
+++ b/packages/login-with-github/index.ts
@@ -10,17 +10,17 @@ const icon = '<svg viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg"><path 
 export default class LoginWithGithubService extends Service {
     static inject = ['oauth'];
     static Config = Schema.object({
-        id: Schema.string().description('Github OAuth AppID').required(),
-        secret: Schema.string().description('Github OAuth Secret').role('secret').required(),
-        endpoint: Schema.string().description('Github Endpoint'),
+        id: Schema.string().description('GitHub OAuth AppID').required(),
+        secret: Schema.string().description('GitHub OAuth Secret').role('secret').required(),
+        endpoint: Schema.string().description('GitHub Endpoint'),
         canRegister: Schema.boolean().default(true),
     });
 
     constructor(ctx: Context, config: ReturnType<typeof LoginWithGithubService.Config>) {
         super(ctx, 'oauth.github');
         ctx.oauth.provide('github', {
-            text: 'Login with Github',
-            name: 'Github',
+            text: 'Login with GitHub',
+            name: 'GitHub',
             icon,
             canRegister: config.canRegister,
             callback: async function callback({ state, code }) {
@@ -72,7 +72,7 @@ export default class LoginWithGithubService extends Service {
             },
         });
         ctx.i18n.load('zh', {
-            'Login With Github': '使用 Github 登录',
+            'Login With GitHub': '使用 GitHub 登录',
         });
     }
 }

--- a/packages/ui-default/locales/ko.yaml
+++ b/packages/ui-default/locales/ko.yaml
@@ -395,8 +395,6 @@ Login to Attend Contest: 대회에 참가하려면 로그인하십시오
 Login to Claim Homework: 과제를 받으려면 로그인하십시오
 Login to Create a Discussion: 토론을 만드려면 로그인하십시오
 Login to Submit: 제출하려면 로그인하십시오
-Login with GitHub: Login with GitHub
-Login with Google: Login with Google
 Login: 로그인
 Logout All Sessions: 모든 세션에서 로그아웃
 Logout This Session: 이 세션에서 로그아웃

--- a/packages/ui-default/locales/ko.yaml
+++ b/packages/ui-default/locales/ko.yaml
@@ -395,7 +395,7 @@ Login to Attend Contest: 대회에 참가하려면 로그인하십시오
 Login to Claim Homework: 과제를 받으려면 로그인하십시오
 Login to Create a Discussion: 토론을 만드려면 로그인하십시오
 Login to Submit: 제출하려면 로그인하십시오
-Login with Github: Login with Github
+Login with GitHub: Login with GitHub
 Login with Google: Login with Google
 Login: 로그인
 Logout All Sessions: 모든 세션에서 로그아웃

--- a/packages/ui-default/locales/zh.yaml
+++ b/packages/ui-default/locales/zh.yaml
@@ -547,8 +547,6 @@ Login to Attend Contest: 登录后参加比赛
 Login to Claim Homework: 登录后认领作业
 Login to Create a Discussion: 登录后创建讨论
 Login to Submit: 登录后递交
-Login with GitHub: 使用 GitHub 登录
-Login with Google: 使用 Google 登录
 Login: 登录
 Logout All Sessions: 注销所有会话
 Logout This Session: 注销该会话

--- a/packages/ui-default/locales/zh.yaml
+++ b/packages/ui-default/locales/zh.yaml
@@ -547,7 +547,7 @@ Login to Attend Contest: 登录后参加比赛
 Login to Claim Homework: 登录后认领作业
 Login to Create a Discussion: 登录后创建讨论
 Login to Submit: 登录后递交
-Login with Github: 使用 Github 登录
+Login with GitHub: 使用 GitHub 登录
 Login with Google: 使用 Google 登录
 Login: 登录
 Logout All Sessions: 注销所有会话

--- a/packages/ui-default/pages/home_settings.page.ts
+++ b/packages/ui-default/pages/home_settings.page.ts
@@ -10,7 +10,7 @@ export default new NamedPage('home_account', () => {
   const $type = $(tpl`
     <select id="type" class="select">
       <option value="gravatar">${i18n('Gravatar')}</option>
-      <option value="github">${i18n('Github')}</option>
+      <option value="github">${i18n('GitHub')}</option>
       <option value="qq">${i18n('QQ')}</option>
       <option value="upload">${i18n('Upload')}</option>
     </select>
@@ -46,7 +46,7 @@ export default new NamedPage('home_account', () => {
       const placeholder = $type.val() === 'gravatar'
         ? 'Email address'
         : $type.val() === 'github'
-          ? 'Github username'
+          ? 'GitHub username'
           : 'QQ ID';
       $text.attr('placeholder', i18n(placeholder));
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected GitHub branding capitalization in README files.

* **Style**
  * Standardized "GitHub" capitalization across UI text and configuration descriptions.

* **Localization**
  * Removed obsolete "Login with Github" and "Login with Google" entries from Korean and Chinese locales; localization keys updated accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes GitHub branding capitalization across READMEs, UI text/placeholders, the GitHub login plugin, and ko/zh locales.
> 
> - **Docs**:
>   - `README.md`, `README-EN.md`, `packages/hydrooj/README.md`: capitalize `GitHub`.
> - **OAuth Plugin** (`packages/login-with-github`):
>   - Update README title and all labels/config descriptions to `GitHub`.
> - **UI**:
>   - `pages/home_settings.page.ts`: use `GitHub` in option and placeholder.
> - **Locales**:
>   - `packages/hydrooj/locales/ko.yaml`, `packages/ui-default/locales/{ko,zh}.yaml`: update/remove `Login with Github` keys; ensure `GitHub` capitalization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4470b349182632a87897dd3f6197fa758a8eb967. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->