### PR TITLE
core: fix oauth callback with mail only

### DIFF
--- a/packages/hydrooj/src/handler/user.ts
+++ b/packages/hydrooj/src/handler/user.ts
@@ -484,13 +484,9 @@ class OauthCallbackHandler extends Handler {
         }
         const udoc = await user.getByEmail('system', r.email);
         if (udoc) {
-            const existing = await this.ctx.oauth.get(args.type, r._id);
-            if (existing && existing !== udoc._id) {
-                throw new BadRequestError('Already binded to another account');
-            }
+            await this.ctx.oauth.set(args.type, r._id, udoc._id);
             await successfulAuth.call(this, udoc);
             this.response.redirect = '/';
-            if (existing !== udoc._id) await this.ctx.oauth.set(args.type, r._id, udoc._id);
             return;
         }
         if (!provider.canRegister) throw new ForbiddenError('No binded account found');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth sign-in now attempts to match and bind by email when no provider ID match exists, reducing duplicate accounts and enabling seamless sign-in to an existing account.
  * Existing provider-ID sign-in behavior unchanged; registration/binding flow unchanged when no matches are found.
  * Improved conflict detection across multiple OAuth providers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->