### PR TITLE
ui: preview: Remove useless download button from dialog actions

### DIFF
--- a/packages/ui-default/components/preview/preview.page.ts
+++ b/packages/ui-default/components/preview/preview.page.ts
@@ -41,7 +41,6 @@ async function startEdit(filename, value, fileCategory = 'file') {
 
 const dialogAction = (id) => [
   tpl`<button class="rounded button" data-action="copy" id="copy-${id}">${i18n('Copy Link')}</button>`,
-  tpl`<button class="rounded button" data-action="download">${i18n('Download')}</button>`,
   tpl`<button class="primary rounded button" data-action="ok">${i18n('Ok')}</button>`,
 ];
 


### PR DESCRIPTION
<img width="401" height="178" alt="503" src="https://github.com/user-attachments/assets/13b79815-3102-489f-84cc-bc99002e629a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the download button from the preview dialog, leaving copy and confirm actions available to users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->