### PR TITLE
ui: preview: Rearrange buttons from dialog actions (fix #1121)

### DIFF
--- a/packages/ui-default/components/preview/preview.page.ts
+++ b/packages/ui-default/components/preview/preview.page.ts
@@ -42,7 +42,7 @@ async function startEdit(filename, value, fileCategory = 'file') {
 const dialogAction = (id) => [
   tpl`<button class="rounded button" data-action="copy" id="copy-${id}">${i18n('Copy Link')}</button>`,
   tpl`<button class="rounded button" data-action="download">${i18n('Download')}</button>`,
-  tpl`<button class="primary rounded button" data-action="ok">${i18n('Ok')}</button>`,
+  tpl`<button class="primary rounded button" data-action="cancel">${i18n('Cancel')}</button>`,
 ];
 
 function bindCopyLink(id, src: string) {
@@ -148,7 +148,7 @@ export async function previewFile(ev?, type = '') {
       });
       bindCopyLink(id, link);
       const action = await dialog.open();
-      if (action === 'ok') window.open(link);
+      if (action === 'download') window.open(link);
       return null;
     }
     if (['mp4', 'webm', 'ogg'].includes(ext)) return previewVideo(link);

--- a/packages/ui-default/components/preview/preview.page.ts
+++ b/packages/ui-default/components/preview/preview.page.ts
@@ -41,8 +41,8 @@ async function startEdit(filename, value, fileCategory = 'file') {
 
 const dialogAction = (id) => [
   tpl`<button class="rounded button" data-action="copy" id="copy-${id}">${i18n('Copy Link')}</button>`,
-  tpl`<button class="rounded button" data-action="download">${i18n('Download')}</button>`,
-  tpl`<button class="primary rounded button" data-action="cancel">${i18n('Cancel')}</button>`,
+  tpl`<button class="rounded button" data-action="cancel">${i18n('Cancel')}</button>`,
+  tpl`<button class="primary rounded button" data-action="download">${i18n('Download')}</button>`,
 ];
 
 function bindCopyLink(id, src: string) {


### PR DESCRIPTION
Buttons before:

 - Copy Link (When clicked: Copy Link)
 - Download (When clicked: Cancel)
 - Ok (When clicked: Download)

Buttons after:

 - Copy Link (When clicked: Copy Link)
 - Cancel (When clicked: Cancel)
 - Download (When clicked: Download)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preview dialog button order updated to show Cancel and Download.
  * Download action routing fixed so selecting Download initiates file download consistently across preview types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->