### PR TITLE
fix: surface download errors on files pages

### DIFF
--- a/packages/ui-default/pages/problem_config.page.tsx
+++ b/packages/ui-default/pages/problem_config.page.tsx
@@ -82,10 +82,15 @@ const page = new NamedPage('problem_config', () => {
 
   async function handleClickDownloadAll() {
     const files = reduxStore.getState().testdata.map((i) => i.name);
-    const { links, pdoc } = await request.post('./files', { operation: 'get_links', files, type: 'testdata' });
-    const targets: { filename: string, url: string }[] = [];
-    for (const filename of Object.keys(links)) targets.push({ filename, url: links[filename] });
-    await download(`${pdoc.docId} ${pdoc.title}.zip`, targets);
+    try {
+      const { links, pdoc } = await request.post('./files', { operation: 'get_links', files, type: 'testdata' });
+      const targets: { filename: string, url: string }[] = [];
+      for (const filename of Object.keys(links)) targets.push({ filename, url: links[filename] });
+      await download(`${pdoc.docId} ${pdoc.title}.zip`, targets);
+    } catch (error) {
+      const err = error as any;
+      Notification.error(err.params ? [err.message, ...err.params].join(' ') : err.message);
+    }
   }
 
   async function uploadConfig(config: object) {

--- a/packages/ui-default/pages/problem_config.page.tsx
+++ b/packages/ui-default/pages/problem_config.page.tsx
@@ -88,8 +88,14 @@ const page = new NamedPage('problem_config', () => {
       for (const filename of Object.keys(links)) targets.push({ filename, url: links[filename] });
       await download(`${pdoc.docId} ${pdoc.title}.zip`, targets);
     } catch (error) {
-      const err = error as any;
-      Notification.error(err.params ? [err.message, ...err.params].join(' ') : err.message);
+      const err = error as { message?: string; params?: unknown };
+      const params = Array.isArray(err.params)
+        ? err.params
+        : err.params
+          ? [String(err.params)]
+          : [];
+      const message = [err.message, ...params].filter(Boolean).join(' ') || i18n('Unknown error');
+      Notification.error(message);
     }
   }
 

--- a/packages/ui-default/pages/problem_files.page.tsx
+++ b/packages/ui-default/pages/problem_files.page.tsx
@@ -26,10 +26,15 @@ const page = new NamedPage('problem_files', () => {
     const type = $(ev.currentTarget).closest('[data-type]').attr('data-type');
     const files = ensureAndGetSelectedFiles(type);
     if (files === null) return;
-    const { links, pdoc } = await request.post('', { operation: 'get_links', files, type });
-    const targets = [];
-    for (const filename of Object.keys(links)) targets.push({ filename, url: links[filename] });
-    await download(`${pdoc.docId} ${pdoc.title} ${type}.zip`, targets);
+    try {
+      const { links, pdoc } = await request.post('', { operation: 'get_links', files, type });
+      const targets = [];
+      for (const filename of Object.keys(links)) targets.push({ filename, url: links[filename] });
+      await download(`${pdoc.docId} ${pdoc.title} ${type}.zip`, targets);
+    } catch (error) {
+      const err = error as any;
+      Notification.error(err.params ? [err.message, ...err.params].join(' ') : err.message);
+    }
   }
 
   async function handleGenerateTestdata(ev) {

--- a/packages/ui-default/pages/problem_files.page.tsx
+++ b/packages/ui-default/pages/problem_files.page.tsx
@@ -32,8 +32,14 @@ const page = new NamedPage('problem_files', () => {
       for (const filename of Object.keys(links)) targets.push({ filename, url: links[filename] });
       await download(`${pdoc.docId} ${pdoc.title} ${type}.zip`, targets);
     } catch (error) {
-      const err = error as any;
-      Notification.error(err.params ? [err.message, ...err.params].join(' ') : err.message);
+      const err = error as { message?: string; params?: unknown };
+      const params = Array.isArray(err.params)
+        ? err.params
+        : err.params
+          ? [String(err.params)]
+          : [];
+      const message = [err.message, ...params].filter(Boolean).join(' ') || i18n('Unknown error');
+      Notification.error(message);
     }
   }
 


### PR DESCRIPTION
## Summary
- show backend error details when downloading selected files
- show backend error details when downloading all testdata

## Related Issues
- closes #1119

## Testing
- not run (frontend-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for download operations in problem files and configuration pages; failed downloads now surface clear, user-facing error notifications instead of failing silently.
  * Error messages now include additional server-provided details when available; successful download behavior and filenames remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->