### PR TITLE
fix: show training and homework titles

### DIFF
--- a/packages/ui-default/templates/homework_detail.html
+++ b/packages/ui-default/templates/homework_detail.html
@@ -8,6 +8,11 @@
   <div class="medium-9 columns">
     <div class="section">
       <div class="section__header">
+        <h1 class="section__title">{{ tdoc.title }}</h1>
+      </div>
+    </div>
+    <div class="section">
+      <div class="section__header">
         <h1 class="section__title">{{ _('Homework Introduction') }}</h1>
       </div>
       <div class="section__body typo richmedia">

--- a/packages/ui-default/templates/training_detail.html
+++ b/packages/ui-default/templates/training_detail.html
@@ -42,6 +42,11 @@
   <div class="medium-9 columns">
   {%- endif -%}
     <div class="section">
+      <div class="section__header">
+        <h1 class="section__title">{{ tdoc.title }}</h1>
+      </div>
+    </div>
+    <div class="section">
       <div class="section__body typo">
         {{ tdoc['content'] }}
       </div>


### PR DESCRIPTION
## Summary
- display training title at the top of training detail pages
- display homework title at the top of homework detail pages

## Related Issues
- closes #890

## Testing
- not run (template-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Homework detail pages now display document titles in a new header section at the top of the page.
  * Training detail pages now display document titles in a new header section at the top of the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->