### PR TITLE
fix: align markdown preview with renderer config

### DIFF
--- a/packages/ui-default/components/editor/mdeditor.ts
+++ b/packages/ui-default/components/editor/mdeditor.ts
@@ -19,17 +19,15 @@ config({
     mdit.options.html = true;
     mdit.options.linkify = true;
     mdit.linkify.tlds('.py', false);
-    mdit.linkify.tlds('.zip', false);
-    mdit.linkify.tlds('.mov', false);
     mdit.use(Media);
+    mdit.use(Imsize);
     mdit.use(Footnote);
     mdit.use(Mark);
-    mdit.use(Imsize);
     mdit.use(Anchor);
     mdit.use(TOC);
+    mdit.use(katex);
     mdit.use(MergeCells);
     mdit.use(xssProtector);
-    mdit.use(katex);
     if (isProblemPage) {
       mdit.core.ruler.before('normalize', 'xss', (state) => {
         state.src = state.src.replace(/file:\/\//g, pagename === 'problem_create' ? `/file/${UserContext._id}/` : './file/');


### PR DESCRIPTION
## Summary
- align markdown preview plugin order with backend renderer
- align linkify configuration for consistent preview rendering

## Related Issues
- closes #1120

## Testing
- not run (frontend-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate plugin registrations in the markdown editor.
  * Enabled LaTeX/KaTeX support for mathematical expressions in Markdown content.
  * Adjusted plugin initialization order for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->