### PR TITLE
fix: harden error messages for UI actions

### DIFF
--- a/packages/ui-default/components/zipDownloader/index.ts
+++ b/packages/ui-default/components/zipDownloader/index.ts
@@ -152,6 +152,13 @@ export async function downloadProblemSet(pids, name = 'Export') {
     await download(`${name}.zip`, targets);
   } catch (e) {
     window.captureException?.(e);
-    Notification.error(`${e.message} ${e.params?.[0]}`);
+    const err = e as { message?: string; params?: unknown };
+    const params = Array.isArray(err.params)
+      ? err.params
+      : err.params
+        ? [String(err.params)]
+        : [];
+    const message = [err.message, ...params].filter(Boolean).join(' ') || i18n('Unknown error');
+    Notification.error(message);
   }
 }


### PR DESCRIPTION
## Summary
- guard error params/message when downloading problem sets
- guard error params/message when generating testdata
- guard error params/message for contest user actions

## Testing
- not run (frontend-only change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened error handling in download operations with improved message formatting and more reliable fallback notifications when unexpected errors occur

* **Improvements**
  * Simplified the user addition workflow by implementing a streamlined inline input method for entering user IDs, replacing the previous dialog-based interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->