### PR TITLE
修复 token 生成函数可预测、登录重定向校验与 OnlyOffice 任意内网访问漏洞

### DIFF
--- a/framework/utils/lib/common.ts
+++ b/framework/utils/lib/common.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from 'crypto';
+
 declare global {
     interface String {
         format: (...args: Array<any>) => string;
@@ -17,8 +19,10 @@ declare global {
 const defaultDict = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
 
 export function randomstring(digit = 32, dict = defaultDict) {
+    if (digit <= 0 || !dict?.length) return '';
+    const bytes = randomBytes(digit);
     let str = '';
-    for (let i = 1; i <= digit; i++) str += dict[Math.floor(Math.random() * dict.length)];
+    for (let i = 0; i < digit; i++) str += dict[bytes[i] % dict.length];
     return str;
 }
 try {


### PR DESCRIPTION
## 危害说明
- H1 可预测 Token/Session：`Math.random()` 非密码学安全，Token/Session/盐存在可预测性与碰撞风险，攻击者可枚举 Token 导致账号接管（含管理员）。
- H2 开放重定向：未限制 `redirect` 目标，攻击者可构造外跳地址进行钓鱼与凭据泄露。
- H3 OnlyOffice JWT 任意签名：可触发 SSRF 访问内网资源；若 `jwtsecret` 使用默认值可伪造 JWT 访问内网文档。

## 修复与变更
- H1：`framework/utils/lib/common.ts` 的 `randomstring()` 改为 `crypto.randomBytes()`，所有依赖 `randomstring` 的 Token/Session/盐升级为密码学安全随机。
- H2：`packages/hydrooj/src/handler/user.ts`、`packages/hydrooj/src/handler/domain.ts` 仅允许站内相对路径或同源绝对 URL，非法值回退主页。
- H3：`packages/onlyoffice/index.ts` JWT 接口要求登录用户，拒绝默认 `jwtsecret`，限制 URL 协议，新增 `onlyoffice.allowedHosts` 白名单，JWT key 改为安全随机。

## 配置变更
- 新增 `onlyoffice.allowedHosts: string[]`，限制可签发文档的域名。
- 未配置时默认允许 `server.url` 与当前请求 Host。

## 测试说明
- 自动化测试：`npm test`（通过）。
- 利用验证：已编写并验证 H2/H3 PoC，H1 理论可行但受限于算力未完成实测。
- 修复由 AI 辅助完成：是。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to specify which external document service hosts are allowed

* **Bug Fixes**
  * Enhanced redirect validation after user authentication to ensure navigation targets are properly sanitized
  * Improved cryptographic randomness for security-sensitive operations
  * Added permission verification for external document access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->