### PR TITLE
core: allow user to manually end contest early

### DIFF
--- a/packages/hydrooj/src/handler/contest.ts
+++ b/packages/hydrooj/src/handler/contest.ts
@@ -191,7 +191,7 @@ export class ContestDetailHandler extends ContestDetailBaseHandler {
     }
 
     @param('tid', Types.ObjectId)
-    async postEnd(domainId: string, tid: ObjectId) {
+    async postEarlyEnd(domainId: string, tid: ObjectId) {
         if (this.tdoc.rule === 'homework') throw new ContestNotFoundError(domainId, tid);
         if (!this.tsdoc?.attend) throw new ContestNotAttendedError(domainId, tid);
         if (!contest.isOngoing(this.tdoc, this.tsdoc)) throw new ContestNotLiveError(domainId, tid);

--- a/packages/hydrooj/src/handler/contest.ts
+++ b/packages/hydrooj/src/handler/contest.ts
@@ -757,7 +757,7 @@ export class ContestUserHandler extends ContestManagementBaseHandler {
             const durationEnd = moment(tsdoc.startAt).add(this.tdoc.duration, 'hours').toDate();
             if (durationEnd <= new Date()) throw new ContestNotLiveError(domainId, tid);
         }
-        await contest.clearEarlyEnd(domainId, tid, uid);
+        await contest.setStatus(domainId, tid, uid, null, { endAt: '' });
         this.back();
     }
 }

--- a/packages/hydrooj/src/handler/contest.ts
+++ b/packages/hydrooj/src/handler/contest.ts
@@ -751,7 +751,7 @@ export class ContestUserHandler extends ContestManagementBaseHandler {
     @param('uid', Types.PositiveInt)
     async postResume(domainId: string, tid: ObjectId, uid: number) {
         const tsdoc = await contest.getStatus(domainId, tid, uid);
-        if (!tsdoc) throw new ContestNotAttendedError(uid);
+        if (!tsdoc?.attend) throw new ContestNotAttendedError(uid);
         if (this.tdoc.endAt <= new Date()) throw new ContestNotLiveError(domainId, tid);
         if (this.tdoc.duration && tsdoc.startAt) {
             const durationEnd = moment(tsdoc.startAt).add(this.tdoc.duration, 'hours').toDate();

--- a/packages/hydrooj/src/handler/contest.ts
+++ b/packages/hydrooj/src/handler/contest.ts
@@ -93,14 +93,16 @@ export class ContestDetailBaseHandler extends Handler {
             }
         }
         if (this.tdoc.duration && this.tsdoc?.startAt) {
-            const endAt = moment(this.tsdoc.startAt).add(this.tdoc.duration, 'hours').toDate();
-            this.tsdoc.endAt = endAt < this.tdoc.endAt ? endAt : this.tdoc.endAt;
+            const computedEndAt = moment(this.tsdoc.startAt).add(this.tdoc.duration, 'hours').toDate();
+            const cappedEndAt = computedEndAt < this.tdoc.endAt ? computedEndAt : this.tdoc.endAt;
+            this.tsdoc.endAt = (this.tsdoc.endAt && this.tsdoc.endAt < cappedEndAt)
+                ? this.tsdoc.endAt : cappedEndAt;
         }
     }
 
     tsdocAsPublic() {
         if (!this.tsdoc) return null;
-        return pick(this.tsdoc, ['attend', 'subscribe', 'startAt', ...(this.tdoc.duration ? ['endAt'] : [])]);
+        return pick(this.tsdoc, ['attend', 'subscribe', 'startAt', ...(this.tdoc.duration || this.tsdoc.endAt ? ['endAt'] : [])]);
     }
 
     @param('tid', Types.ObjectId, true)
@@ -184,6 +186,15 @@ export class ContestDetailHandler extends ContestDetailBaseHandler {
     async postSubscribe(domainId: string, tid: ObjectId, subscribe = false) {
         if (!this.tsdoc?.attend) throw new ContestNotAttendedError(domainId, tid);
         await contest.setStatus(domainId, tid, this.user._id, { subscribe: subscribe ? 1 : 0 });
+        this.back();
+    }
+
+    @param('tid', Types.ObjectId)
+    async postEnd(domainId: string, tid: ObjectId) {
+        if (this.tdoc.rule === 'homework') throw new ContestNotLiveError(tid);
+        if (!this.tsdoc?.attend) throw new ContestNotAttendedError(domainId, tid);
+        if (!contest.isOngoing(this.tdoc, this.tsdoc)) throw new ContestNotLiveError(tid);
+        await contest.setStatus(domainId, tid, this.user._id, { endAt: new Date() });
         this.back();
     }
 }
@@ -698,10 +709,15 @@ export class ContestUserHandler extends ContestManagementBaseHandler {
     @param('tid', Types.ObjectId)
     async get(domainId: string, tid: ObjectId) {
         const tsdocs = await contest.getMultiStatus(domainId, { docId: tid }).project({
-            uid: 1, attend: 1, startAt: 1, unrank: 1,
+            uid: 1, attend: 1, startAt: 1, unrank: 1, endAt: 1,
         }).toArray();
         for (const tsdoc of tsdocs) {
-            tsdoc.endAt = (this.tdoc.duration && tsdoc.startAt) ? moment(tsdoc.startAt).add(this.tdoc.duration, 'hours').toDate() : null;
+            const computedEndAt = (this.tdoc.duration && tsdoc.startAt)
+                ? moment(tsdoc.startAt).add(this.tdoc.duration, 'hours').toDate() : null;
+            if (computedEndAt) {
+                const cappedEndAt = computedEndAt < this.tdoc.endAt ? computedEndAt : this.tdoc.endAt;
+                tsdoc.endAt = (tsdoc.endAt && tsdoc.endAt < cappedEndAt) ? tsdoc.endAt : cappedEndAt;
+            }
         }
         const udict = await user.getListForRender(
             domainId, [this.tdoc.owner, ...tsdocs.map((i) => i.uid)],
@@ -726,6 +742,20 @@ export class ContestUserHandler extends ContestManagementBaseHandler {
         const tsdoc = await contest.getStatus(domainId, tid, uid);
         if (!tsdoc) throw new ContestNotAttendedError(uid);
         await contest.setStatus(domainId, tid, uid, { unrank: !tsdoc.unrank });
+        this.back();
+    }
+
+    @param('tid', Types.ObjectId)
+    @param('uid', Types.PositiveInt)
+    async postResume(domainId: string, tid: ObjectId, uid: number) {
+        const tsdoc = await contest.getStatus(domainId, tid, uid);
+        if (!tsdoc) throw new ContestNotAttendedError(uid);
+        if (this.tdoc.endAt <= new Date()) throw new ContestNotLiveError(tid);
+        if (this.tdoc.duration && tsdoc.startAt) {
+            const durationEnd = moment(tsdoc.startAt).add(this.tdoc.duration, 'hours').toDate();
+            if (durationEnd <= new Date()) throw new ContestNotLiveError(tid);
+        }
+        await contest.clearEarlyEnd(domainId, tid, uid);
         this.back();
     }
 }

--- a/packages/hydrooj/src/handler/contest.ts
+++ b/packages/hydrooj/src/handler/contest.ts
@@ -176,7 +176,7 @@ export class ContestDetailHandler extends ContestDetailBaseHandler {
     @param('code', Types.String, true)
     async postAttend(domainId: string, tid: ObjectId, code = '') {
         this.checkPerm(PERM.PERM_ATTEND_CONTEST);
-        if (contest.isDone(this.tdoc)) throw new ContestNotLiveError(tid);
+        if (contest.isDone(this.tdoc)) throw new ContestNotLiveError(domainId, tid);
         if (this.tdoc._code && code !== this.tdoc._code) throw new InvalidTokenError('Contest Invitation', code);
         await contest.attend(domainId, tid, this.user._id, { subscribe: 1 });
         this.back();
@@ -192,9 +192,9 @@ export class ContestDetailHandler extends ContestDetailBaseHandler {
 
     @param('tid', Types.ObjectId)
     async postEnd(domainId: string, tid: ObjectId) {
-        if (this.tdoc.rule === 'homework') throw new ContestNotLiveError(tid);
+        if (this.tdoc.rule === 'homework') throw new ContestNotFoundError(domainId, tid);
         if (!this.tsdoc?.attend) throw new ContestNotAttendedError(domainId, tid);
-        if (!contest.isOngoing(this.tdoc, this.tsdoc)) throw new ContestNotLiveError(tid);
+        if (!contest.isOngoing(this.tdoc, this.tsdoc)) throw new ContestNotLiveError(domainId, tid);
         await contest.setStatus(domainId, tid, this.user._id, { endAt: new Date() });
         this.back();
     }
@@ -752,10 +752,10 @@ export class ContestUserHandler extends ContestManagementBaseHandler {
     async postResume(domainId: string, tid: ObjectId, uid: number) {
         const tsdoc = await contest.getStatus(domainId, tid, uid);
         if (!tsdoc) throw new ContestNotAttendedError(uid);
-        if (this.tdoc.endAt <= new Date()) throw new ContestNotLiveError(tid);
+        if (this.tdoc.endAt <= new Date()) throw new ContestNotLiveError(domainId, tid);
         if (this.tdoc.duration && tsdoc.startAt) {
             const durationEnd = moment(tsdoc.startAt).add(this.tdoc.duration, 'hours').toDate();
-            if (durationEnd <= new Date()) throw new ContestNotLiveError(tid);
+            if (durationEnd <= new Date()) throw new ContestNotLiveError(domainId, tid);
         }
         await contest.clearEarlyEnd(domainId, tid, uid);
         this.back();

--- a/packages/hydrooj/src/handler/contest.ts
+++ b/packages/hydrooj/src/handler/contest.ts
@@ -93,10 +93,11 @@ export class ContestDetailBaseHandler extends Handler {
             }
         }
         if (this.tdoc.duration && this.tsdoc?.startAt) {
-            const computedEndAt = moment(this.tsdoc.startAt).add(this.tdoc.duration, 'hours').toDate();
-            const cappedEndAt = computedEndAt < this.tdoc.endAt ? computedEndAt : this.tdoc.endAt;
-            this.tsdoc.endAt = (this.tsdoc.endAt && this.tsdoc.endAt < cappedEndAt)
-                ? this.tsdoc.endAt : cappedEndAt;
+            this.tsdoc.endAt = moment.min([
+                moment(this.tsdoc.startAt).add(this.tdoc.duration, 'hours'),
+                moment(this.tdoc.endAt),
+                ...(this.tsdoc.endAt ? [moment(this.tsdoc.endAt)] : []),
+            ]).toDate();
         }
     }
 
@@ -712,11 +713,12 @@ export class ContestUserHandler extends ContestManagementBaseHandler {
             uid: 1, attend: 1, startAt: 1, unrank: 1, endAt: 1,
         }).toArray();
         for (const tsdoc of tsdocs) {
-            const computedEndAt = (this.tdoc.duration && tsdoc.startAt)
-                ? moment(tsdoc.startAt).add(this.tdoc.duration, 'hours').toDate() : null;
-            if (computedEndAt) {
-                const cappedEndAt = computedEndAt < this.tdoc.endAt ? computedEndAt : this.tdoc.endAt;
-                tsdoc.endAt = (tsdoc.endAt && tsdoc.endAt < cappedEndAt) ? tsdoc.endAt : cappedEndAt;
+            if (this.tdoc.duration && tsdoc.startAt) {
+                tsdoc.endAt = moment.min([
+                    moment(tsdoc.startAt).add(this.tdoc.duration, 'hours'),
+                    moment(this.tdoc.endAt),
+                    ...(tsdoc.endAt ? [moment(tsdoc.endAt)] : []),
+                ]).toDate();
             }
         }
         const udict = await user.getListForRender(

--- a/packages/hydrooj/src/model/contest.ts
+++ b/packages/hydrooj/src/model/contest.ts
@@ -62,12 +62,14 @@ export function isNotStarted(tdoc: Tdoc) {
 
 export function isOngoing(tdoc: Tdoc, tsdoc?: any) {
     const now = new Date();
+    if (tsdoc?.endAt && tsdoc.endAt <= now) return false;
     if (tsdoc && tdoc.duration && tsdoc.startAt <= new Date(Date.now() - Math.floor(tdoc.duration * Time.hour))) return false;
     return (tdoc.beginAt <= now && now < tdoc.endAt);
 }
 
 export function isDone(tdoc: Tdoc, tsdoc?: any) {
     if (tdoc.endAt <= new Date()) return true;
+    if (tsdoc?.endAt && tsdoc.endAt <= new Date()) return true;
     if (tsdoc && tdoc.duration && tsdoc.startAt <= new Date(Date.now() - Math.floor(tdoc.duration * Time.hour))) return true;
     return false;
 }
@@ -942,6 +944,13 @@ export function getMultiStatus(domainId: string, query: any) {
 
 export function setStatus(domainId: string, tid: ObjectId, uid: number, $set: any) {
     return document.setStatus(domainId, document.TYPE_CONTEST, tid, uid, $set);
+}
+
+export function clearEarlyEnd(domainId: string, tid: ObjectId, uid: number) {
+    return document.collStatus.findOneAndUpdate(
+        { domainId, docType: document.TYPE_CONTEST, docId: tid, uid },
+        { $unset: { endAt: '' } },
+    );
 }
 
 export function count(domainId: string, query: any) {

--- a/packages/hydrooj/src/model/contest.ts
+++ b/packages/hydrooj/src/model/contest.ts
@@ -942,15 +942,8 @@ export function getMultiStatus(domainId: string, query: any) {
     return document.getMultiStatus(domainId, document.TYPE_CONTEST, query);
 }
 
-export function setStatus(domainId: string, tid: ObjectId, uid: number, $set: any) {
-    return document.setStatus(domainId, document.TYPE_CONTEST, tid, uid, $set);
-}
-
-export function clearEarlyEnd(domainId: string, tid: ObjectId, uid: number) {
-    return document.collStatus.findOneAndUpdate(
-        { domainId, docType: document.TYPE_CONTEST, docId: tid, uid },
-        { $unset: { endAt: '' } },
-    );
+export function setStatus(domainId: string, tid: ObjectId, uid: number, $set?: any, $unset?: any) {
+    return document.setStatus(domainId, document.TYPE_CONTEST, tid, uid, $set, $unset);
 }
 
 export function count(domainId: string, query: any) {

--- a/packages/hydrooj/src/model/document.ts
+++ b/packages/hydrooj/src/model/document.ts
@@ -295,11 +295,16 @@ export function getMultiStatusWithoutDomain<K extends keyof DocStatusType>(
 
 export async function setStatus<K extends keyof DocStatusType>(
     domainId: string, docType: K, docId: DocStatusType[K]['docId'], uid: number,
-    args: UpdateFilter<DocStatusType[K]>['$set'], returnDocument: 'before' | 'after' = 'after',
+    $set: UpdateFilter<DocStatusType[K]>['$set'] | null,
+    $unset?: UpdateFilter<DocStatusType[K]>['$unset'] | null,
+    returnDocument: 'before' | 'after' = 'after',
 ): Promise<DocStatusType[K]> {
+    const op: UpdateFilter<DocStatusType[K]> = {};
+    if ($set && Object.keys($set).length) op.$set = $set;
+    if ($unset && Object.keys($unset).length) op.$unset = $unset;
     return await collStatus.findOneAndUpdate(
         { domainId, docType, docId, uid },
-        { $set: args },
+        op,
         {
             upsert: true,
             returnDocument,

--- a/packages/hydrooj/src/model/solution.ts
+++ b/packages/hydrooj/src/model/solution.ts
@@ -74,7 +74,7 @@ class SolutionModel {
         if (!doc) throw new SolutionNotFoundError(domainId, psid);
         const before = await document.setStatus(
             domainId, document.TYPE_PROBLEM_SOLUTION, psid, uid,
-            { vote: value }, 'before',
+            { vote: value }, null, 'before',
         );
         let inc = value;
         if (before?.vote) inc -= before.vote;

--- a/packages/ui-default/locales/zh.yaml
+++ b/packages/ui-default/locales/zh.yaml
@@ -195,6 +195,7 @@ Confirm deleting the selected roles?: 您确定删除所选角色吗？
 Confirm deleting this comment? Its replies will be deleted as well.: 确认删除这个评论吗？回复会被同时删除。
 Confirm deleting this domain? This action cannot be undone.: '确认删除此域？此操作无法撤销。'
 Confirm deleting this reply?: 确认删除这个回复吗？
+Confirm end contest early? You will not be able to submit after this.: 确认提前结束比赛吗？之后您将无法提交代码。
 Confirm rejudge this problem?: 确定要重测这道题吗？
 Confirm removing the selected users?: 您确定将所选用户移除吗？
 Confirm to delete the file?: 确认删除此文件吗？
@@ -376,6 +377,7 @@ Email Visibility: Email 可见性
 Email: 电子邮件
 Enabled: 开启
 End at: 结束于
+End Contest Early: 提前结束比赛
 End Date: 结束日期
 End Time: 结束时间
 Enroll Training: 参加训练

--- a/packages/ui-default/locales/zh.yaml
+++ b/packages/ui-default/locales/zh.yaml
@@ -210,6 +210,7 @@ Content copied to clipboard!: 内容已复制到剪贴板！
 content: 内容
 Content: 内容
 Contest Maintainer: 比赛管理员
+Contest resumed.: 比赛已恢复。
 Contest scoreboard is not visible.: 当前比赛成绩表隐藏，暂不可显示。
 Contest Scoreboard: 比赛成绩表
 Contest Settings: 比赛设置

--- a/packages/ui-default/pages/contest.page.ts
+++ b/packages/ui-default/pages/contest.page.ts
@@ -1,8 +1,7 @@
 import { formatSeconds } from '@hydrooj/utils/lib/common';
 import NProgress from 'nprogress';
-import { confirm } from 'vj/components/dialog';
 import { NamedPage } from 'vj/misc/Page';
-import { addSpeculationRules, i18n, request, tpl } from 'vj/utils';
+import { addSpeculationRules, tpl } from 'vj/utils';
 
 const contestTimer = $(tpl`<pre class="contest-timer" style="display:none"></pre>`);
 contestTimer.appendTo(document.body);
@@ -32,18 +31,5 @@ export default new NamedPage(['contest_detail', 'contest_problemlist', 'contest_
         ],
       },
     }],
-  });
-
-  $(document).on('click', '[name="end_contest"]', async (ev) => {
-    const tid = $(ev.currentTarget).data('tid');
-    const yes = await confirm(i18n('Confirm end contest early? You will not be able to submit after this.'));
-    if (!yes) return;
-    try {
-      await request.post(UiContext.url('contest_detail', { tid }), { operation: 'end' });
-      window.location.reload();
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error(error);
-    }
   });
 });

--- a/packages/ui-default/pages/contest.page.ts
+++ b/packages/ui-default/pages/contest.page.ts
@@ -1,14 +1,15 @@
 import { formatSeconds } from '@hydrooj/utils/lib/common';
 import NProgress from 'nprogress';
+import { confirm } from 'vj/components/dialog';
 import { NamedPage } from 'vj/misc/Page';
-import { addSpeculationRules, tpl } from 'vj/utils';
+import { addSpeculationRules, i18n, request, tpl } from 'vj/utils';
 
 const contestTimer = $(tpl`<pre class="contest-timer" style="display:none"></pre>`);
 contestTimer.appendTo(document.body);
 
 export default new NamedPage(['contest_detail', 'contest_problemlist', 'contest_detail_problem', 'contest_scoreboard'], () => {
   const beginAt = new Date((UiContext.tdoc.duration && UiContext.tsdoc?.startAt) || UiContext.tdoc.beginAt).getTime();
-  const endAt = new Date((UiContext.tdoc.duration && UiContext.tsdoc?.endAt) || UiContext.tdoc.endAt).getTime();
+  const endAt = new Date(UiContext.tsdoc?.endAt || UiContext.tdoc.endAt).getTime();
   NProgress.configure({ trickle: false, showSpinner: false, minimum: 0 });
   function updateProgress() {
     const now = Date.now();
@@ -31,5 +32,18 @@ export default new NamedPage(['contest_detail', 'contest_problemlist', 'contest_
         ],
       },
     }],
+  });
+
+  $(document).on('click', '[name="end_contest"]', async (ev) => {
+    const tid = $(ev.currentTarget).data('tid');
+    const yes = await confirm(i18n('Confirm end contest early? You will not be able to submit after this.'));
+    if (!yes) return;
+    try {
+      await request.post(UiContext.url('contest_detail', { tid }), { operation: 'end' });
+      window.location.reload();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+    }
   });
 });

--- a/packages/ui-default/pages/contest_user.page.ts
+++ b/packages/ui-default/pages/contest_user.page.ts
@@ -52,59 +52,45 @@ const page = new NamedPage('contest_user', () => {
     return this;
   };
 
+  async function handlePostRequest(params, successMessage) {
+    try {
+      const res = await request.post('', params);
+      if (res.url && res.url !== window.location.href) window.location.href = res.url;
+      else {
+        Notification.success(successMessage);
+        pjax.request({ push: false });
+      }
+    } catch (error) {
+      Notification.error([error.message, ...error.params].join(' '));
+    }
+  }
+
   async function handleClickAddUser() {
     const action = await addUserDialog.clear().open();
     if (action !== 'ok') return;
     const unrank = addUserDialog.$dom.find('[name="unrank"]').prop('checked');
     const uids = userSelect.value();
-    try {
-      const res = await request.post('', {
-        operation: 'add_user',
-        uids: uids.join(','),
-        unrank,
-      });
-      if (res.url && res.url !== window.location.href) window.location.href = res.url;
-      else {
-        Notification.success(i18n('User added.'));
-        pjax.request({ push: false });
-      }
-    } catch (error) {
-      Notification.error([error.message, ...error.params].join(' '));
-    }
+    await handlePostRequest({
+      operation: 'add_user',
+      uids: uids.join(','),
+      unrank,
+    }, i18n('User added.'));
   }
 
   async function handleEditRank(ev) {
     const uid = $(ev.target).data('uid');
-    try {
-      const res = await request.post('', {
-        operation: 'rank',
-        uid,
-      });
-      if (res.url && res.url !== window.location.href) window.location.href = res.url;
-      else {
-        Notification.success(i18n('Ranking status updated.'));
-        pjax.request({ push: false });
-      }
-    } catch (error) {
-      Notification.error([error.message, ...error.params].join(' '));
-    }
+    await handlePostRequest({
+      operation: 'rank',
+      uid,
+    }, i18n('Ranking status updated.'));
   }
 
   async function handleResume(ev) {
     const uid = $(ev.target).data('uid');
-    try {
-      const res = await request.post('', {
-        operation: 'resume',
-        uid,
-      });
-      if (res.url && res.url !== window.location.href) window.location.href = res.url;
-      else {
-        Notification.success(i18n('Contest resumed.'));
-        pjax.request({ push: false });
-      }
-    } catch (error) {
-      Notification.error([error.message, ...error.params].join(' '));
-    }
+    await handlePostRequest({
+      operation: 'resume',
+      uid,
+    }, i18n('Contest resumed.'));
   }
 
   $('[name="add_user"]').on('click', () => handleClickAddUser());

--- a/packages/ui-default/pages/contest_user.page.ts
+++ b/packages/ui-default/pages/contest_user.page.ts
@@ -90,8 +90,26 @@ const page = new NamedPage('contest_user', () => {
     }
   }
 
+  async function handleResume(ev) {
+    const uid = $(ev.target).data('uid');
+    try {
+      const res = await request.post('', {
+        operation: 'resume',
+        uid,
+      });
+      if (res.url && res.url !== window.location.href) window.location.href = res.url;
+      else {
+        Notification.success(i18n('Contest resumed.'));
+        pjax.request({ push: false });
+      }
+    } catch (error) {
+      Notification.error([error.message, ...error.params].join(' '));
+    }
+  }
+
   $('[name="add_user"]').on('click', () => handleClickAddUser());
   $(document).on('click', '[name="edit_rank"]', handleEditRank);
+  $(document).on('click', '[name="resume_contest"]', handleResume);
 });
 
 export default page;

--- a/packages/ui-default/templates/partials/contest_sidebar.html
+++ b/packages/ui-default/templates/partials/contest_sidebar.html
@@ -68,6 +68,13 @@
       <li class="menu__item"><a class="menu__link" href="{{ url('contest_problemlist', tid=tdoc.docId) }}">
         <span class="icon icon-unordered_list"></span> {{ _('Problem List') }}
       </a></li>
+      {% if tsdoc.attend and model.contest.isOngoing(tdoc, tsdoc) and tdoc.rule !== 'homework' %}
+      <li class="menu__item">
+        <a class="menu__link" name="end_contest" data-tid="{{ tdoc.docId }}">
+          <span class="icon icon-delete"></span> {{ _('End Contest Early') }}
+        </a>
+      </li>
+      {% endif %}
     {% endif %}{# not attend and not done #}
     {% if model.contest.canShowScoreboard.call(handler, tdoc, False) %}
       <li class="menu__item"><a class="menu__link" href="{{ url('contest_scoreboard', tid=tdoc.docId) }}">

--- a/packages/ui-default/templates/partials/contest_sidebar.html
+++ b/packages/ui-default/templates/partials/contest_sidebar.html
@@ -68,11 +68,14 @@
       <li class="menu__item"><a class="menu__link" href="{{ url('contest_problemlist', tid=tdoc.docId) }}">
         <span class="icon icon-unordered_list"></span> {{ _('Problem List') }}
       </a></li>
-      {% if tsdoc.attend and model.contest.isOngoing(tdoc, tsdoc) and tdoc.rule !== 'homework' %}
+      {% if page_name == 'contest_detail' and tsdoc.attend and model.contest.isOngoing(tdoc, tsdoc) and tdoc.rule !== 'homework' %}
       <li class="menu__item">
-        <a class="menu__link" name="end_contest" data-tid="{{ tdoc.docId }}">
-          <span class="icon icon-delete"></span> {{ _('End Contest Early') }}
-        </a>
+        <form action="{{ url('contest_detail', tid=tdoc.docId) }}" method="POST" onsubmit='return confirm({{ _("Confirm end contest early? You will not be able to submit after this.")|json|safe }});'>
+          <input type="hidden" name="operation" value="early_end">
+          <button class="menu__link" type="submit">
+            <span class="icon icon-delete"></span> {{ _('End Contest Early') }}
+          </button>
+        </form>
       </li>
       {% endif %}
     {% endif %}{# not attend and not done #}

--- a/packages/ui-default/templates/partials/contest_user.html
+++ b/packages/ui-default/templates/partials/contest_user.html
@@ -10,6 +10,9 @@
     <td class="col--rank">{{ _('UnRank') if tsdoc.unrank else _('Rank') }}</td>
     <td class="col--actions">
       <a name="edit_rank" data-uid="{{ tsdoc.uid }}">{{ _('Rank') if tsdoc.unrank else _('UnRank') }}</a>
+      {% if tsdoc.endAt and tsdoc.endAt < tdoc.endAt %}
+      | <a name="resume_contest" data-uid="{{ tsdoc.uid }}">{{ _('Resume') }}</a>
+      {% endif %}
     </td>
   </tr>
   {%- endfor -%}

--- a/packages/ui-default/templates/partials/contest_user.html
+++ b/packages/ui-default/templates/partials/contest_user.html
@@ -10,7 +10,7 @@
     <td class="col--rank">{{ _('UnRank') if tsdoc.unrank else _('Rank') }}</td>
     <td class="col--actions">
       <a name="edit_rank" data-uid="{{ tsdoc.uid }}">{{ _('Rank') if tsdoc.unrank else _('UnRank') }}</a>
-      {% if tsdoc.endAt and tsdoc.endAt < tdoc.endAt %}
+      {% if tsdoc.endAt and tsdoc.endAt < tdoc.endAt and tdoc.endAt.getTime() > Date.now() and (not tdoc.duration or not tsdoc.startAt or tsdoc.startAt.getTime() + tdoc.duration * 3600000 > Date.now()) %}
       | <a name="resume_contest" data-uid="{{ tsdoc.uid }}">{{ _('Resume') }}</a>
       {% endif %}
     </td>


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End contest early action in sidebar with confirmation; per-user "Resume" control on participant list; server endpoints to trigger early-end and resume.

* **Improvements**
  * Consistent end-time handling using per-contest and per-user values.
  * Status serialization now reliably exposes end time when present.
  * Server-side liveness and resume/early-end validations tightened.

* **Localization**
  * Added Simplified Chinese strings for early-end and resume actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->