### PR TITLE
core: fix judger login if builtin login disabled

### DIFF
--- a/packages/hydrojudge/src/hosts/hydro.ts
+++ b/packages/hydrojudge/src/hosts/hydro.ts
@@ -221,7 +221,8 @@ export default class Hydro implements Session {
     async login() {
         log.info('[%s] Updating session', this.config.host);
         const res = await this.post('login', {
-            uname: this.config.uname, password: this.config.password, rememberme: 'on',
+            uname: this.config.uname, password: this.config.password,
+            rememberme: 'on', judger: 'on',
         });
         const setCookie = res.headers['set-cookie'];
         await this.setCookie(Array.isArray(setCookie) ? setCookie.join(';') : setCookie);

--- a/packages/hydrojudge/src/hosts/hydro.ts
+++ b/packages/hydrojudge/src/hosts/hydro.ts
@@ -222,7 +222,7 @@ export default class Hydro implements Session {
         log.info('[%s] Updating session', this.config.host);
         const res = await this.post('login', {
             uname: this.config.uname, password: this.config.password,
-            rememberme: 'on', judger: 'on',
+            rememberme: 'on', judge: 'on',
         });
         const setCookie = res.headers['set-cookie'];
         await this.setCookie(Array.isArray(setCookie) ? setCookie.join(';') : setCookie);

--- a/packages/hydrooj/src/handler/user.ts
+++ b/packages/hydrooj/src/handler/user.ts
@@ -57,15 +57,15 @@ class UserLoginHandler extends Handler {
     @param('redirect', Types.String, true)
     @param('tfa', Types.String, true)
     @param('authnChallenge', Types.String, true)
-    @param('judger', Types.Boolean, true)
+    @param('judge', Types.Boolean, true)
     async post(
         domainId: string, uname: string, password: string, rememberme = false, redirect = '',
-        tfa = '', authnChallenge = '', judger = false,
+        tfa = '', authnChallenge = '', judge = false,
     ) {
-        if (!judger && !system.get('server.login')) throw new BuiltinLoginError();
+        if (!judge && !system.get('server.login')) throw new BuiltinLoginError();
         let udoc = await user.getByEmail(domainId, uname);
         udoc ||= await user.getByUname(domainId, uname);
-        if (judger && !system.get('server.login') && !udoc?.hasPriv(PRIV.PRIV_JUDGE)) throw new BuiltinLoginError();
+        if (judge && !system.get('server.login') && !udoc?.hasPriv(PRIV.PRIV_JUDGE)) throw new BuiltinLoginError();
         if (!udoc) throw new UserNotFoundError(uname);
         if (system.get('system.contestmode') && !udoc.hasPriv(PRIV.PRIV_EDIT_SYSTEM)) {
             if (udoc._loginip && udoc._loginip !== this.request.ip) throw new ValidationError('ip');

--- a/packages/hydrooj/src/handler/user.ts
+++ b/packages/hydrooj/src/handler/user.ts
@@ -57,13 +57,15 @@ class UserLoginHandler extends Handler {
     @param('redirect', Types.String, true)
     @param('tfa', Types.String, true)
     @param('authnChallenge', Types.String, true)
+    @param('judger', Types.Boolean, true)
     async post(
         domainId: string, uname: string, password: string, rememberme = false, redirect = '',
-        tfa = '', authnChallenge = '',
+        tfa = '', authnChallenge = '', judger = false,
     ) {
-        if (!system.get('server.login')) throw new BuiltinLoginError();
+        if (!judger && !system.get('server.login')) throw new BuiltinLoginError();
         let udoc = await user.getByEmail(domainId, uname);
         udoc ||= await user.getByUname(domainId, uname);
+        if (judger && !system.get('server.login') && !udoc?.hasPriv(PRIV.PRIV_JUDGE)) throw new BuiltinLoginError();
         if (!udoc) throw new UserNotFoundError(uname);
         if (system.get('system.contestmode') && !udoc.hasPriv(PRIV.PRIV_EDIT_SYSTEM)) {
             if (udoc._loginip && udoc._loginip !== this.request.ip) throw new ValidationError('ip');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit judge-mode login support: clients now include a judge flag when authenticating.
  * Login rules updated so judge-mode access is allowed when the server permits it or when the target account has judge privileges; standard login behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->