### PR TITLE
core: always pick tsdoc endAt field

### DIFF
--- a/packages/hydrooj/src/handler/contest.ts
+++ b/packages/hydrooj/src/handler/contest.ts
@@ -195,7 +195,8 @@ export class ContestDetailHandler extends ContestDetailBaseHandler {
         if (this.tdoc.rule === 'homework') throw new ContestNotFoundError(domainId, tid);
         if (!this.tsdoc?.attend) throw new ContestNotAttendedError(domainId, tid);
         if (!contest.isOngoing(this.tdoc, this.tsdoc)) throw new ContestNotLiveError(domainId, tid);
-        await contest.setStatus(domainId, tid, this.user._id, { endAt: new Date() });
+        const now = new Date();
+        await contest.setStatus(domainId, tid, this.user._id, { endAt: now, ...(!this.tsdoc.startAt ? { startAt: now } : {}) });
         this.back();
     }
 }

--- a/packages/hydrooj/src/handler/problem.ts
+++ b/packages/hydrooj/src/handler/problem.ts
@@ -366,8 +366,7 @@ export class ProblemDetailHandler extends ContestDetailBaseHandler {
                         : problem.canViewBy(this.pdoc, this.user) ? 'correction' : 'none',
         };
         if (this.tdoc && this.tsdoc) {
-            const fields = ['attend', 'startAt'];
-            if (this.tdoc.duration) fields.push('endAt');
+            const fields = ['attend', 'startAt', 'endAt'];
             if (contest.canShowSelfRecord.call(this, this.tdoc, true)) fields.push('detail');
             this.tsdoc = pick(this.tsdoc, fields);
             this.response.body.tsdoc = this.tsdoc;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Contest end time handling improved when contests end early
* Problem detail information fields now consistently display in contest mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->