### PR TITLE
core: migrate notp to otpauth

### DIFF
--- a/packages/hydrooj/package.json
+++ b/packages/hydrooj/package.json
@@ -44,7 +44,7 @@
         "mongodb-uri": "^0.9.7",
         "nanoid": "^5.1.11",
         "nodemailer": "^8.0.7",
-        "notp": "^2.0.3",
+        "otpauth": "^9.5.1",
         "p-queue": "^9.2.0",
         "sanitize-filename": "^1.6.4",
         "schemastery": "^3.18.0",
@@ -53,7 +53,6 @@
         "superagent": "^10.3.0",
         "superagent-proxy": "^3.0.0",
         "tar": "6.2.1",
-        "thirty-two": "^1.0.2",
         "ua-parser-js": "1.0.41"
     },
     "devDependencies": {
@@ -66,7 +65,6 @@
         "@types/mime-types": "^3.0.1",
         "@types/mongodb-uri": "^0.9.4",
         "@types/nodemailer": "^8.0.0",
-        "@types/notp": "^2.0.5",
         "@types/semver": "^7.7.1",
         "@types/superagent": "^8.1.9",
         "@types/superagent-proxy": "^3.0.4",

--- a/packages/hydrooj/src/lib/verifyTFA.ts
+++ b/packages/hydrooj/src/lib/verifyTFA.ts
@@ -1,8 +1,7 @@
-import notp from 'notp';
-import b32 from 'thirty-two';
+import { Secret, TOTP } from 'otpauth';
 
 export function verifyTFA(secret: string, code?: string) {
-    if (!code || !code.length) return null;
-    const bin = b32.decode(secret);
-    return notp.totp.verify(code.replace(/\W+/g, ''), bin);
+    if (!code || !code.length) return false;
+    const totp = new TOTP({ secret: Secret.fromBase32(secret), algorithm: 'SHA1', digits: 6, period: 30 });
+    return totp.validate({ token: code.replace(/\W+/g, '') }) !== null;
 }


### PR DESCRIPTION
Last update of `notp` package is 12 years ago, this PR migrate verifyTFA to a morden package `otpauth`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication verification dependencies for improved library compatibility and maintenance.

* **Refactor**
  * Refactored internal two-factor authentication verification logic to utilize updated libraries and improve code efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->