### PR TITLE
judge: enhance validation for communication type config

### DIFF
--- a/packages/hydrojudge/src/cases.ts
+++ b/packages/hydrojudge/src/cases.ts
@@ -15,14 +15,19 @@ function isValidConfig(config) {
     if (config.type !== 'objective' && config.count > (getConfig('testcases_max') || 100)) {
         throw new FormatError('Too many testcases. Cancelled.');
     }
+    if (config.type === 'communication') {
+        if (!Number.isInteger(config.num_processes) || config.num_processes <= 0) {
+            throw new FormatError('Number of processes must be a positive integer for communication type.');
+        }
+        if (config.num_processes > getConfig('processLimit')) {
+            throw new FormatError('Number of processes larger than processLimit');
+        }
+    }
     const time = (config.num_processes || 1) * Math.sum(...config.subtasks.flatMap((subtask) => subtask.cases.map((c) => c.time)));
     if (time > (getConfig('total_time_limit') || 60) * 1000) {
         throw new FormatError('Total time limit longer than {0}s. Cancelled.', [+getConfig('total_time_limit') || 60]);
     }
     const memMax = Math.max(...config.subtasks.flatMap((subtask) => subtask.cases.map((c) => c.memory)));
-    if (config.type === 'communication' && (config.num_processes || 2) > getConfig('processLimit')) {
-        throw new FormatError('Number of processes larger than processLimit');
-    }
     if (memMax > parseMemoryMB(getConfig('memoryMax'))) throw new FormatError('Memory limit larger than memory_max');
     if (!['default', 'strict'].includes(config.checker_type || 'default') && !config.checker) {
         throw new FormatError('You did not specify a checker.');


### PR DESCRIPTION
`num_processes` should be greater than 0. So let's enhance the validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now requires the number of processes to be explicitly provided and positive, with clearer errors for missing or invalid values.
  * Configurations that exceed the allowed process limit are now rejected to prevent runtime issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hydro-dev/Hydro/pull/1163)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->