### PR TITLE
core: delete old session after recreate

### DIFF
--- a/packages/hydrooj/src/service/layers/base.ts
+++ b/packages/hydrooj/src/service/layers/base.ts
@@ -57,6 +57,7 @@ export default async (ctx: KoaContext, next: Next) => {
     if (ctx.session._id && !ctx.session.recreate) {
         await token.update(ctx.session._id, token.TYPE_SESSION, expireSeconds, omit(ctx.session, ['_id', 'recreate']));
     } else {
+        if (ctx.session._id) await token.del(ctx.session._id, token.TYPE_SESSION);
         Object.assign(ctx.session, { createIp: request.ip, createUa: ua, createHost: request.host });
         [ctx.session._id] = await token.add(token.TYPE_SESSION, expireSeconds, omit(ctx.session, ['_id', 'recreate']));
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session management to properly clean up old session tokens when sessions are recreated, preventing orphaned session records from accumulating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->