### PR TITLE
ui-default: fix domain template name

### DIFF
--- a/packages/ui-default/backendlib/template.ts
+++ b/packages/ui-default/backendlib/template.ts
@@ -177,7 +177,7 @@ export class TemplateService extends Service {
       h.ctx = h.ctx.extend({ domain: h.domain });
       h.renderHTML = ((orig) => function (name: string, args: Record<string, any>) {
         const s = name.split('.');
-        let templateName = `${s[0]}.${args.domainId}.${s[1]}`;
+        let templateName = `${s[0]}.${h.domain._id}.${s[1]}`;
         if (!that.registry[templateName]) templateName = name;
         return orig(templateName, args);
       })(h.renderHTML).bind(h);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed template selection to correctly identify domains, ensuring templates are properly rendered for the intended domain context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->