### PR TITLE
fix(judge): treat empty output files as existing

### DIFF
--- a/packages/hydrojudge/src/sandbox.ts
+++ b/packages/hydrojudge/src/sandbox.ts
@@ -136,13 +136,15 @@ function adaptResult(result: SandboxResult, params: Parameter): SandboxAdaptedRe
     const outname = params.filename ? `${params.filename}.out` : 'stdout';
     ret.files = result.files || {};
     ret.fileIds = result.fileIds || {};
-    if (ret.fileIds[outname]) ret.fileIds.stdout = ret.fileIds[outname];
-    if (params.filename && !ret.fileIds[outname] && !ret.files[outname]) {
+    const hasOutputFileId = Object.prototype.hasOwnProperty.call(ret.fileIds, outname);
+    const hasOutputFile = Object.prototype.hasOwnProperty.call(ret.files, outname);
+    if (hasOutputFileId) ret.fileIds.stdout = ret.fileIds[outname];
+    if (params.filename && !hasOutputFileId && !hasOutputFile) {
         result.error = 'Output file not found';
         ret.status = STATUS.STATUS_RUNTIME_ERROR;
     }
-    ret.stdout = ret.files[outname] || '';
-    ret.stderr = ret.files.stderr || result.error || '';
+    ret.stdout = ret.files[outname] ?? '';
+    ret.stderr = ret.files.stderr ?? result.error ?? '';
     if (result.error) ret.error = result.error;
     return ret;
 }


### PR DESCRIPTION
fix(judge): treat empty output files as existing

When using file IO mode, HydroJudge checked output file existence with a truthy value check on `ret.files[outname]`.

This caused a valid zero-byte output file, such as an empty `user.out`, to be treated as missing because an empty string is falsy in JavaScript. As a result, pretests with empty output incorrectly failed with `Output file not found`.

Check whether the output file key exists instead of checking whether its content is truthy, and preserve empty stdout/stderr with nullish coalescing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of sandbox output files so missing results are reported more reliably.
  * Preserved empty `stdout` and `stderr` content instead of treating it as missing.
  * If an expected output file is not found, the run now surfaces a clearer runtime error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->