### PR TITLE
core: add bucketEndpoint config for s3 storage

### DIFF
--- a/packages/hydrooj/src/service/storage.ts
+++ b/packages/hydrooj/src/service/storage.ts
@@ -85,6 +85,7 @@ const FileSetting = Schema.intersect([
             bucket: Schema.string().default('hydro'),
             region: Schema.string().default('us-east-1'),
             pathStyle: Schema.boolean().default(true),
+            bucketEndpoint: Schema.boolean().default(false),
         }),
     ] as const),
 ] as const);
@@ -114,6 +115,7 @@ class RemoteStorageService {
                 bucket,
                 region,
                 pathStyle,
+                bucketEndpoint,
                 endPointForUser,
                 endPointForJudge,
             } = this.config;
@@ -121,6 +123,7 @@ class RemoteStorageService {
             const base = {
                 region,
                 forcePathStyle: pathStyle,
+                bucketEndpoint,
                 credentials: {
                     accessKeyId: accessKey,
                     secretAccessKey: secretKey,


### PR DESCRIPTION
## Background
Aliyun OSS does not support path-style.

When a user sets `endPoint` to a custom domain (or CDN domain) that already points to a specific OSS bucket, if `bucketEndpoint` is not enabled, the AWS S3 SDK may still prepend the bucket name to the host. This causes an invalid hostname and prevents resources from being accessed correctly.

## What This PR Changes
This PR introduces a new S3 storage config option: `bucketEndpoint`.

- Adds `bucketEndpoint: boolean` to the S3 config schema (default: `false`)
- Passes `bucketEndpoint` into S3 client initialization
- Applies the same setting to both the primary S3 client and alternative endpoint clients

## Why
For users using OSS bucket-bound custom domains, enabling `bucketEndpoint` avoids duplicated bucket prefixes in hostnames, so upload/download/sign URL flows can work as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring S3 bucket endpoints in remote storage settings.
  * The option defaults to disabled, preserving existing storage behavior unless enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->