### PR TITLE
ui-default: fix num_processes config for communication problem (#1200)

### DIFF
--- a/packages/ui-default/components/problemconfig/ProblemConfigEditor.tsx
+++ b/packages/ui-default/components/problemconfig/ProblemConfigEditor.tsx
@@ -51,6 +51,7 @@ export function configYamlFormat(config: ProblemConfigFile) {
         && (['default', 'strict'].includes(formatConfig.checker_type) || !formatConfig.checker_type)) return;
       if (key === 'interactor' && config.type !== 'interactive') return;
       if (key === 'multi_pass' && (!Number.isInteger(config.multi_pass) || config.multi_pass <= 1 || config.multi_pass > 20)) return;
+      if (key === 'num_processes' && config.type !== 'communication') return;
       if (key === 'subtasks') {
         formatConfig[key] = [];
         config[key].forEach((subtask) => {

--- a/packages/ui-default/components/problemconfig/reducer/config.ts
+++ b/packages/ui-default/components/problemconfig/reducer/config.ts
@@ -51,6 +51,9 @@ export default function reducer(state = {
       const next = { ...state, [action.key]: action.value };
       if (action.key === 'score' && action.value) next.score = +next.score;
       if (action.key === 'checker_type' && action.value === 'other') next.checker_type = 'syzoj';
+      if (action.key === 'type' && action.value === 'communication' && next.num_processes == null) {
+        next.num_processes = 2;
+      }
       if (!action.value || (action.value instanceof Array && !action.value.join(''))) delete next[action.key];
       return next;
     }


### PR DESCRIPTION
## Summary

Fix the bug that communication problem configuration `num_processes` default value not saved to config.yaml.

## Related Issues

Fixes #1200

## Changes

- when switching to communication problem, explicitly set the `num_processes` to `2` by default. 
  *(Previously, the UI set default value `2` in the form but the actual value remains `undefined`.)*
- Add a check to prevent incorrect updates to `num_processes` from certain interactions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Communication problems now include the process count in generated configurations.
  * The process count defaults to 2 when configuring a communication problem, while existing values are preserved.
  * Other problem types no longer include an irrelevant process count setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->