### PR TITLE
fix #1202

### DIFF
--- a/packages/hydrooj/src/handler/user.ts
+++ b/packages/hydrooj/src/handler/user.ts
@@ -317,7 +317,7 @@ class UserRegisterWithCodeHandler extends Handler {
     ) {
         const provider = this.ctx.oauth.providers[this.tdoc.identity.provider];
         if (!provider) throw new SystemError(`OAuth provider ${this.tdoc.identity.provider} not found`);
-        if (provider.lockUsername) uname = this.tdoc.identity.username;
+        if (provider.lockUsername) uname = this.tdoc.username;
         if (!Types.Username[1](uname)) throw new ValidationError('uname');
         if (password !== verify) throw new VerifyPasswordError();
         const randomEmail = `${randomstring(12)}@invalid.local`; // some random email to remove in the future

--- a/packages/hydrooj/src/handler/user.ts
+++ b/packages/hydrooj/src/handler/user.ts
@@ -303,8 +303,12 @@ class UserRegisterWithCodeHandler extends Handler {
     }
 
     async get() {
+        const provider = this.ctx.oauth.providers[this.tdoc.identity.provider];
         this.response.template = 'user_register_with_code.html';
-        this.response.body = this.tdoc;
+        this.response.body = {
+            ...this.tdoc,
+            lockUsername: !!provider?.lockUsername,
+        };
     }
 
     @param('password', Types.Password)

--- a/packages/ui-default/templates/user_register_with_code.html
+++ b/packages/ui-default/templates/user_register_with_code.html
@@ -12,13 +12,13 @@
     <div>
       <label class="inverse material textbox">
         {{ _('Username') }}
-        <input name="uname" value="{{ username or '' }}" type="text" autofocus>
+        <input name="uname" value="{{ username or '' }}" type="text" {% if lockUsername %}readonly{% else %}autofocus{% endif %}>
       </label>
     </div>
     <div>
       <label class="inverse material textbox">
         {{ _('Password') }}
-        <input name="password" type="password">
+        <input name="password" type="password" {% if lockUsername %}autofocus{% endif %}>
       </label>
     </div>
     <div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed registration with OAuth providers that lock username selection to use the correct username provided by the authentication token.
  * Registration now correctly indicates when username selection is locked by the authentication provider.
  * Improved registration form focus behavior and prevented editing usernames when selection is locked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->