### PR TITLE
framework: no-store cache for json responses & vary Accept

### DIFF
--- a/framework/framework/base.ts
+++ b/framework/framework/base.ts
@@ -125,6 +125,7 @@ export default (logger, xff, xhost) => async (ctx: KoaContext, next: Next) => {
         }
     } finally {
         if (!request.websocket) {
+            ctx.vary('Accept');
             if (response.etag && request.headers['if-none-match'] === response.etag) {
                 ctx.response.status = 304;
             } else if (response.redirect && !request.json) {
@@ -138,6 +139,9 @@ export default (logger, xff, xhost) => async (ctx: KoaContext, next: Next) => {
                     || (request.json
                         ? 'application/json'
                         : ctx.response.type);
+                if (ctx.response.type === 'application/json' && !ctx.response.get('Cache-Control')) {
+                    ctx.set('Cache-Control', 'no-store');
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem

The same URL can return different representations depending on the request:
`request.json` is derived from the `Accept` header, so an XHR/fetch with
`Accept: application/json` gets raw JSON, while a normal navigation to the
same URL gets the rendered HTML page. However, JSON responses were sent
without any `Cache-Control` header and without `Vary: Accept`, so the
browser HTTP cache stored them keyed only by URL.

Concretely: open `/p/:pid/config`, let the frontend fetch it as JSON,
navigate to another page, then press the browser Back button — the browser
replays the cached JSON response for the navigation and the user is dumped
into a page of raw JSON instead of the UI.

## Fix

- **JSON responses now default to `Cache-Control: no-store`** — added only
  when the response does not already set a `Cache-Control` header. JSON
  output often contains user-specific data and should not be stored by
  browsers or shared caches on its own. Responses with an ETag still get
  `Cache-Control: public` as before, and headers explicitly set by handlers
  are left untouched.
- **All non-websocket responses now send `Vary: Accept`** — since the same
  URL can return either HTML or JSON via content negotiation, caches must
  key on the `Accept` header. Otherwise a cached JSON representation can be
  wrongly served to a normal page navigation (or vice versa).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JSON responses now default to `Cache-Control: no-store` when no caching policy is specified.
  * Non-websocket responses now vary by the `Accept` header for more accurate content negotiation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->